### PR TITLE
feat: bl engine - scripting, local scopes, silent scaffolding & docs overhaul

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 # Boiler
 
-**Code Once. Reuse Forever.**
+**Build Less. Ship More.**
 
-Store reusable code snippets and project templates locally. Automatic versioning, template variables, zero config.
+Fetch code from anywhere. Scaffold full features in one command. Reuse everything across every project.
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Go Version](https://img.shields.io/badge/Go-1.25+-00ADD8?logo=go)](https://golang.org)
@@ -14,29 +14,93 @@ Store reusable code snippets and project templates locally. Automatic versioning
 [![Sponsor](https://img.shields.io/badge/Sponsor-Boiler-2ea043?logo=githubsponsors&logoColor=white)](https://github.com/sponsors/rishiyaduwanshi)
 [![Use Cases](https://img.shields.io/badge/Use%20Cases-Explore-f97316)](https://boiler.iamabhinav.dev/guides/usecases/)
 
-[Documentation](https://boiler.iamabhinav.dev) • [Use Cases](https://boiler.iamabhinav.dev/guides/usecases/)
+[Documentation](https://boiler.iamabhinav.dev) • [Use Cases](https://boiler.iamabhinav.dev/guides/usecases/) • [Guides](https://boiler.iamabhinav.dev/guides/introduction/)
 
 </div>
 
-**Pre-release - v0.x.x** - Feel free to use it, break it, Every idea and bug report shapes what we build next.
+**Pre-release - v0.x.x** - Feel free to use it, break it. Every idea and bug report shapes what we build next.
 
 > Open an [issue](https://github.com/rishiyaduwanshi/boiler/issues) or start a [discussion](https://github.com/rishiyaduwanshi/boiler/discussions) anytime.
 
 ---
 
-## Why Boiler?
-
-Stop installing entire packages for one function. Stop copy-pasting code between projects.
+## Instant `.gitignore` - 500+ Templates, One Command
 
 ```bash
-# Store once
-bl store ./utils/errorHandler.js
-
-# Reuse anywhere
-bl add errorHandler
+bl gi Node        # Node.js
+bl gi Python      # Python
+bl gi Go          # Go
+bl gi Global/macOS  # macOS global
+bl gi community/JetBrains+all  # JetBrains IDEs
 ```
 
-**Perfect for:** Utility functions, config files, project boilerplates, API templates.
+No browser, no copy-paste. Powered by the official [github/gitignore](https://github.com/github/gitignore) repo with 225+ popular templates and 300+ community templates.
+
+---
+
+## Pull Files From GitHub - Without `git clone`
+
+```bash
+# Grab a single file from any public repo
+bl use alice/snippets:js/errorHandler.js ./src/utils
+
+# Grab a specific subfolder as a project template
+bl use vercel/next.js:examples/blog ./my-blog
+
+# Entire repo (no clone, no zip download)
+bl use rishiyaduwanshi/express-starter ./my-api
+
+# From GitLab or any direct URL
+bl use https://gitlab.com/myorg/templates:Dockerfile .
+```
+
+---
+
+## Scaffold Full Features in One Command
+
+Write a `.bl` script that creates routes, controllers, and auto-wires them into your existing codebase:
+
+```bash
+bl new feat user
+# ✓ Created src/routes/user.route.js
+# ✓ Created src/controllers/user.controller.js
+# ✓ Injected import into src/api.js
+# ✓ Injected app.use('/user', userRouter) into src/api.js
+```
+
+```bash
+# bl/commands/feat.bl
+__var bl__feature = bl__1.lowercase()
+__var bl__Feature = bl__1.capitalize()
+
+add route.js ./src/routes/bl__feature.route.js --local
+add controller.js ./src/controllers/bl__feature.controller.js --local
+
+inject ./src/api.js -d imports -a -c `
+import bl__featureRouter from './routes/bl__feature.route.js';
+`
+inject ./src/api.js -d routes -a -c `
+app.use('/bl__feature', bl__featureRouter);
+`
+```
+
+---
+
+## Store Once. Reuse Everywhere.
+
+```bash
+# Store a snippet with template variables
+bl store utils/dbConnect.js
+# ✓ Stored snippet 'dbConnect@1.js'
+
+# Reuse in any project
+cd ~/new-service
+bl add dbConnect ./src
+#   bl__DB_URL [mongodb://localhost:27017]: ...
+# ✓ Added snippet → ./src/dbConnect.js
+```
+
+Variables replaced. Metadata stripped. Clean code, ready to use.
 
 ---
 
@@ -64,137 +128,86 @@ bl version
 
 ---
 
-## Quick Start
-
-```bash
-# 1. Store a file as snippet
-bl store ./middleware/auth.js
-# ✓ Stored snippet 'auth@1.js' at ~/.boiler/store/...
-
-# 2. Add to any project
-bl add auth
-# ✓ Added snippet 'auth@1.js' to boiler/auth.js
-
-# 3. Store a directory as stack (bl init required first)
-cd ./my-template
-bl init        # creates boiler.stack.json
-bl store       # stores it
-
-# 4. Add a stack
-bl add my-template
-# ✓ Added stack 'my-template@1' to boiler/my-template
-
-# 5. List everything
-bl ls
-```
-
----
-
-## Template Variables
-
-Create configurable snippets:
-
-```js
-// errorHandler.js
-// __var bl__LOG_LEVEL = error
-// __var bl__EMAIL = admin@example.com
-
-function handleError(err) {
-  console[bl__LOG_LEVEL](err.message);
-  sendEmail('bl__EMAIL', err);
-}
-```
-
-```bash
-bl add errorHandler
-#   bl__LOG_LEVEL [error]: warn
-#   bl__EMAIL [admin@example.com]: dev@app.com
-# ✓ Added snippet 'errorHandler@1.js' to boiler/errorHandler.js
-# (metadata stripped, variables replaced)
-```
-
-- Identifiers beginning with "bl__" are reserved for Boiler variables.
-
-
----
-
 ## Features
 
-- ✅ **Automatic Versioning** - `@1`, `@2`, etc.
-- ✅ **Template Variables** - `bl__VAR_NAME` syntax with prompts
-- ✅ **Reusable Config Vars** - `bl var KEY=value` and inline `bl__KEY` references in commands
-- ✅ **Powerful Aliases** - Support for positional arguments (`bl__1`, `bl__2`) and inline variables
-- ✅ **Remote Fetching** - GitHub, GitLab, Bitbucket, custom registries, direct URLs
-- ✅ **Language Agnostic** - JS, Python, Go, Java, TS, Rust, C++, etc.
-- ✅ **Stack Templates** - Store entire project folders
-- ✅ **Zero Config** - Works immediately after install
-- ✅ **Cross-Platform** - Windows, Linux, macOS
+- ✅ **Remote Fetching** - GitHub, GitLab, Bitbucket, direct URLs, custom registries
+- ✅ **Zero-Clone** - Pull individual files or entire repos without `git clone`
+- ✅ **Automation Scripts** - `.bl` scripts scaffold multiple files and inject code
+- ✅ **Template Variables** - `bl__VAR_NAME` syntax with interactive prompts
+- ✅ **Built-in `gi` Alias** - 500+ gitignore templates via `bl gi <language>`
+- ✅ **Aliases + Vars** - Build your own one-word power commands
+- ✅ **Local & Global Stores** - Per-project `bl/` directory or global `~/.boiler`
+- ✅ **Automatic Versioning** - `@1`, `@2`, etc. per resource
+- ✅ **Language Agnostic** - JS, Python, Go, Rust, Java, Docker, configs - anything
+- ✅ **Framework Agnostic** - Express, Next.js, Django, Spring, whatever you use
+- ✅ **OS Agnostic** - Windows, Linux, macOS
 - ✅ **Self-Updating** - `bl self update`
-
----
-
-## Remote Fetching
-
-Pull snippets and stacks from anywhere — provider is auto-detected from the URL:
-
-```bash
-# GitHub (short format)
-bl add rishiyaduwanshi/boiler-express -r
-
-# GitHub (full URL)
-bl add https://github.com/alice/my-stack -r
-
-# GitLab
-bl add https://gitlab.com/alice/my-stack -r
-
-# Bitbucket
-bl add https://bitbucket.org/alice/my-stack -r
-
-# File from GitHub repo (snippet)
-bl add alice/snippets:js/errorHandler.js -r
-
-# Direct archive URL
-bl add https://mysite.com/template.zip -r
-
-# From configured registry
-bl conf --set-registry https://github.com/myteam/boiler
-bl add express@1 -r
-```
-
-**One-shot fetch (no local store):**
-```bash
-bl use alice/my-stack
-bl use https://gitlab.com/alice/my-stack
-bl use https://mysite.com/template.zip
-```
 
 ---
 
 ## Commands
 
 ```bash
-bl init              # Initialize stack/snippet config
-bl store [path]      # Store file/folder
-bl add <name> [path] # Add snippet/stack (default destination: ./boiler)
-bl add <name> --spread # Spread stack contents into destination
-bl alias [k|k=v]     # List, get, or set command aliases (supports bl__N args)
-bl unalias <k>       # Remove a command alias
-bl var [k|k=v]       # List, get, or set reusable variables
-bl unvar <k>         # Remove a reusable variable
-bl use <resource> [path]  # One-shot remote fetch (e.g., bl use bl__ORG/repo)
-bl ls                # List all resources
-bl search <query>    # Search by name (-r to search remote)
-bl info <name>       # Show resource details
-bl clean             # Remove resources
-bl path              # Show installation paths
-bl conf              # View/edit configuration
-bl self update       # Update Boiler to latest
-bl self uninstall    # Uninstall Boiler
-bl version           # Show version
-bl --help            # Full command list
+bl store <file>              # Store a file as snippet
+bl store <folder>            # Store a directory as stack (bl init required first)
+bl add <name> [path]         # Add snippet or stack (default: ./boiler)
+bl add <name> -r             # Fetch from remote and save to local store
+bl use <url-or-repo> [path]  # One-shot fetch - no local caching
+bl gi <language>             # Instant gitignore (bl gi Node, bl gi Python, etc.)
+bl new <script> [args]       # Run a .bl automation script
+bl ls                        # List all stored resources
+bl search <query> [-r]       # Search local or remote store
+bl info <name>               # Show resource details
+bl alias [k=v]               # Create a command shortcut
+bl var [k=v]                 # Set a reusable variable
+bl init                      # Initialize stack/snippet config
+bl conf                      # View or edit configuration
+bl clean                     # Remove resources from store
+bl path                      # Show installation paths
+bl self update               # Update Boiler to latest
+bl self uninstall            # Uninstall Boiler
+bl version                   # Show version
 ```
 
 **Full docs:** [boiler.iamabhinav.dev](https://boiler.iamabhinav.dev)
+
+---
+
+## Project-Local Store
+
+For project-specific templates that shouldn't be in your global store:
+
+```bash
+bl init -c          # Creates boiler.local.json with scope: local
+```
+
+```
+my-project/
+├── boiler.local.json          ← scope: local
+└── bl/
+    ├── commands/
+    │   └── cmp.bl             ← bl new cmp <ComponentName>
+    └── snippets/
+        └── component.jsx      ← local template
+```
+
+All `bl` commands automatically use `bl/` instead of `~/.boiler/` when `scope: local` is set.
+
+---
+
+## Team Registry
+
+Host a shared snippet library on GitHub. Any developer pulls standardized patterns in seconds:
+
+```bash
+# One-time setup
+bl conf --set-registry https://github.com/myteam/boiler-snippets
+
+# Pull approved patterns (cached locally for offline use)
+bl add jwtAuth -r
+bl add rateLimiter -r
+bl add mongoConfig -r
+```
 
 ---
 

--- a/distributions/npm/README.md
+++ b/distributions/npm/README.md
@@ -127,7 +127,7 @@ bl add errorHandler
 
 ## Remote Fetching
 
-Pull snippets and stacks from anywhere — provider is auto-detected from the URL:
+Pull snippets and stacks from anywhere - provider is auto-detected from the URL:
 
 ```bash
 # GitHub (short format)

--- a/internal/cli/add/cmd.go
+++ b/internal/cli/add/cmd.go
@@ -61,8 +61,8 @@ Template Variables:
 - Variables are replaced and metadata comments are removed in the final file.
 
 Command Variables:
-- Use :name to resolve values from config vars (set via 'bl var').
-- Example: bl add express@1 -r --registry :team_reg
+- Use bl__varname to resolve values from config vars (set via 'bl var').
+- Example: bl add express@1 -r --registry bl__team_reg
 
 Stacks are also versioned and can be added by name or with explicit version.
 
@@ -142,8 +142,8 @@ Supported remote formats:
   # Remote: one-time registry override
   bl add express@1 -r --registry https://github.com/myorg/boiler
 
-	# Remote: registry from config variable
-	bl add express@1 -r --registry :team_reg
+	# Remote: registry from config variable (set via: bl var team_reg=<url>)
+	bl add express@1 -r --registry bl__team_reg
 
 	# One-shot fetch without saving to store
 	bl add alice/my-stack -r --no-store`,

--- a/internal/cli/add/local.go
+++ b/internal/cli/add/local.go
@@ -31,6 +31,12 @@ func AddSnippet(st *store.Store, name, destPath string, opts Options, cfg *confi
 	if len(meta.Variables) > 0 {
 		fmt.Println("Template variables found:")
 		for varName, defaultValue := range meta.Variables {
+			// If value is provided via Env or Config, skip the prompt and use it silently
+			if val, ok, _ := utils.LookupVar(cfg.Vars, varName); ok && val != "" {
+				varReplacements[varName] = val
+				continue
+			}
+
 			defaultValue = utils.ResolveSnippetVarDefault(varName, defaultValue, cfg.Vars)
 			prompt := fmt.Sprintf("  %s", varName)
 			value, err := utils.PromptWithDefault(prompt, defaultValue)

--- a/internal/cli/add/local.go
+++ b/internal/cli/add/local.go
@@ -20,6 +20,31 @@ func AddSnippet(st *store.Store, name, destPath string, opts Options, cfg *confi
 		return fmt.Errorf(utils.ErrResourceNotFound, "snippet file", snippetPath)
 	}
 
+	// Extract base name without version: errorHandler@1.js -> errorHandler.js
+	baseName, _, ext := store.ParseResourceName(name)
+	destFileName := baseName + ext
+	if opts.Name != "" {
+		destFileName = opts.Name
+	}
+	destFile := filepath.Join(destPath, destFileName)
+
+	if utils.FileExists(destFile) && !opts.Force {
+		return fmt.Errorf(utils.ErrFileAlreadyExists, destFile)
+	}
+
+	if err := ProcessSnippetFile(snippetPath, destFile, cfg); err != nil {
+		return err
+	}
+
+	fmt.Printf(utils.MsgSnippetAdded, name, destFile)
+	if logger != nil {
+		logger.Info(fmt.Sprintf("Snippet added: %s -> %s", name, destFile))
+	}
+	return nil
+}
+
+// ProcessSnippetFile parses metadata, prompts for variables, and copies the content to destFile.
+func ProcessSnippetFile(snippetPath, destFile string, cfg *config.Config) error {
 	// Parse snippet metadata to check for variables
 	meta, err := utils.ParseSnippetMetadata(snippetPath)
 	if err != nil {
@@ -47,27 +72,11 @@ func AddSnippet(st *store.Store, name, destPath string, opts Options, cfg *confi
 		}
 	}
 
-	// Extract base name without version: errorHandler@1.js -> errorHandler.js
-	baseName, _, ext := store.ParseResourceName(name)
-	destFileName := baseName + ext
-	if opts.Name != "" {
-		destFileName = opts.Name
-	}
-	destFile := filepath.Join(destPath, destFileName)
-
-	if utils.FileExists(destFile) && !opts.Force {
-		return fmt.Errorf(utils.ErrFileAlreadyExists, destFile)
-	}
-
 	// Copy file with variable replacement
 	if err := utils.CopyFileWithVariables(snippetPath, destFile, varReplacements); err != nil {
 		return fmt.Errorf("failed to copy snippet: %w", err)
 	}
 
-	fmt.Printf(utils.MsgSnippetAdded, name, destFile)
-	if logger != nil {
-		logger.Info(fmt.Sprintf("Snippet added: %s -> %s", name, destFile))
-	}
 	return nil
 }
 

--- a/internal/cli/add/remote.go
+++ b/internal/cli/add/remote.go
@@ -62,7 +62,19 @@ func ResourceFromRemote(resource, destPath string, resourceType ResourceType, no
 				return fmt.Errorf(utils.ErrFileAlreadyExists, destFile)
 			}
 
-			if err := remote.FetchSnippet(remotePath, destFile); err != nil {
+			tmpFile, err := os.CreateTemp("", "boiler-snippet-*")
+			if err != nil {
+				return fmt.Errorf("failed to create temp file: %w", err)
+			}
+			tmpPath := tmpFile.Name()
+			tmpFile.Close()
+			defer os.Remove(tmpPath)
+
+			if err := remote.FetchSnippet(remotePath, tmpPath); err != nil {
+				return err
+			}
+
+			if err := ProcessSnippetFile(tmpPath, destFile, cfg); err != nil {
 				return err
 			}
 

--- a/internal/cli/alias/cmd.go
+++ b/internal/cli/alias/cmd.go
@@ -23,30 +23,30 @@ var Cmd = &cobra.Command{
 	Long: `Manage command aliases stored in boiler.conf.json.
 
 Usage patterns:
+
   bl alias              List all aliases
   bl alias name=cmd     Set or update an alias
   bl alias name         Get one alias value
   bl unalias name       Remove an alias (use 'unalias' command)
 
 Positional Arguments & Variables:
-  Aliases support dynamic positional arguments (bl__1, bl__2) and inline variables (bl__VAR_NAME).
-  When positional arguments are used, any trailing unconsumed arguments are automatically appended.
+- Aliases support dynamic positional arguments (bl__1, bl__2, ...) and inline variables (bl__VAR_NAME).
+- When positional arguments are used, any trailing unconsumed arguments are automatically appended.
 
-Alias names are normalized internally:
-  - Names are case-insensitive
-  - Hyphens and underscores are preserved
+Alias names are case-insensitive. Hyphens and underscores are preserved.
 
-Examples:
-  # Simple aliases
-  bl alias ll=ls
-  bl alias s=search
+` + "```" + `bash
+# Simple aliases
+bl alias ll=ls
+bl alias s=search
 
-  # Alias with positional arguments (e.g. bl gi Node -> fetches Node.gitignore)
-  bl alias gi='use github/gitignore:bl__1.gitignore'
+# Alias with positional argument - bl gi Node fetches Node.gitignore
+bl alias gi='add github/gitignore:bl__1.gitignore . -m .gitignore -r'
 
-  # Alias with inline variables
-  bl var org=rishiyaduwanshi
-  bl alias templates='search --registry https://github.com/bl__org/boiler'`,
+# Alias referencing a stored var
+bl var org=rishiyaduwanshi
+bl alias templates='search --registry https://github.com/bl__org/boiler'
+` + "```",
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		var err error

--- a/internal/cli/clean/cmd.go
+++ b/internal/cli/clean/cmd.go
@@ -297,7 +297,7 @@ func interactiveClean() error {
 		fmt.Println(utils.MsgCancelled)
 		return nil
 	default:
-		fmt.Fprintf(os.Stderr, "invalid choice %q — valid options: k (stacks), n (snippets), a (all), q (quit)\n", choice)
+		fmt.Fprintf(os.Stderr, "invalid choice %q - valid options: k (stacks), n (snippets), a (all), q (quit)\n", choice)
 		return fmt.Errorf("invalid choice %q", choice)
 	}
 }

--- a/internal/cli/new/cmd.go
+++ b/internal/cli/new/cmd.go
@@ -1,0 +1,103 @@
+package new
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/rishiyaduwanshi/boiler/internal/config"
+	"github.com/rishiyaduwanshi/boiler/internal/engine"
+	"github.com/rishiyaduwanshi/boiler/internal/utils"
+	"github.com/spf13/cobra"
+)
+
+var (
+	cfg    *config.Config
+	logger *utils.Logger
+)
+
+// Setup injects the configuration and logger
+func Setup(c *config.Config, l *utils.Logger) {
+	cfg = c
+	logger = l
+}
+
+// Cmd represents the 'new' command
+var Cmd = &cobra.Command{
+	Use:   "new [script_name] [args...]",
+	Short: "Generate code using a Boiler script (.bl)",
+	Long: `Run a Boiler script (.bl) to generate, inject, or modify code in your project.
+	
+Boiler automatically parses any flags (like --ts or --port=3000) and maps them to script variables.
+It looks for the script in the './bl/' folder of your current project.`,
+	Example: `  # Run the routes.bl script with positional arguments
+  bl new routes user auth
+
+  # Run with flags
+  bl new routes --ts --port=3000`,
+	DisableFlagParsing: true, // Crucial: allows dynamic user-defined flags like --ts
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Because DisableFlagParsing is true, the very first arg might be the global flag
+		// if passed after 'new' (e.g. bl new --help). We should handle it if needed.
+		if len(args) == 0 {
+			return fmt.Errorf("please provide a script name (e.g., 'bl new routes')")
+		}
+
+		if args[0] == "-h" || args[0] == "--help" {
+			return cmd.Help()
+		}
+
+		scriptName := args[0]
+		// In Boiler, local scripts are in the `bl/` directory of the project
+		scriptPath := filepath.Join("bl", scriptName+".bl")
+
+		if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
+			return fmt.Errorf("script '%s' not found. Ensure '%s' exists in your project", scriptName, scriptPath)
+		}
+
+		// Parse dynamic arguments and flags
+		vars := make(map[string]string)
+		positionalIndex := 1
+
+		for i := 1; i < len(args); i++ {
+			arg := args[i]
+
+			// Global flags shouldn't be passed to the script variables ideally, but for now we consume all.
+			if arg == "--verbose" || arg == "-V" {
+				continue // skip global verbose flag
+			}
+
+			if strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-") {
+				// It's a flag
+				flagRaw := strings.TrimLeft(arg, "-")
+				if strings.Contains(flagRaw, "=") {
+					parts := strings.SplitN(flagRaw, "=", 2)
+					vars["bl__"+parts[0]] = parts[1]
+				} else {
+					vars["bl__"+flagRaw] = "true"
+				}
+			} else {
+				// It's a positional argument
+				vars[fmt.Sprintf("bl__%d", positionalIndex)] = arg
+				positionalIndex++
+			}
+		}
+
+		if logger != nil {
+			logger.Info(fmt.Sprintf("Executing Boiler script: %s", scriptPath))
+		} else {
+			fmt.Printf("Executing Boiler script: %s\n", scriptPath)
+		}
+
+		err := engine.ParseAndExecute(scriptPath, vars)
+		if err != nil {
+			return fmt.Errorf("script execution failed: %w", err)
+		}
+
+		if logger != nil {
+			logger.Info(fmt.Sprintf("Successfully executed '%s'", scriptName))
+		}
+		return nil
+	},
+}

--- a/internal/cli/new/cmd.go
+++ b/internal/cli/new/cmd.go
@@ -49,11 +49,24 @@ It looks for the script in the './bl/' folder of your current project.`,
 		}
 
 		scriptName := args[0]
+
+		// Find project root automatically like npm/mise
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get current directory: %w", err)
+		}
+
+		projectRoot := cwd
+		nearestConfig, err := config.FindNearestConfig(cwd)
+		if err == nil && nearestConfig != "" {
+			projectRoot = filepath.Dir(nearestConfig)
+		}
+
 		// In Boiler, local scripts are in the `bl/commands/` directory of the project
-		scriptPath := filepath.Join("bl", "commands", scriptName+".bl")
+		scriptPath := filepath.Join(projectRoot, "bl", "commands", scriptName+".bl")
 
 		if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
-			return fmt.Errorf("script '%s' not found. Ensure '%s' exists in your project", scriptName, scriptPath)
+			return fmt.Errorf("script '%s' not found. Looked for it at: %s", scriptName, scriptPath)
 		}
 
 		// Parse dynamic arguments and flags
@@ -85,12 +98,17 @@ It looks for the script in the './bl/' folder of your current project.`,
 		}
 
 		if logger != nil {
-			logger.Info(fmt.Sprintf("Executing Boiler script: %s", scriptPath))
+			logger.Info(fmt.Sprintf("Executing Boiler script: %s from %s", scriptPath, projectRoot))
 		} else {
-			fmt.Printf("Executing Boiler script: %s\n", scriptPath)
+			fmt.Printf("Executing Boiler script: %s from %s\n", scriptPath, projectRoot)
 		}
 
-		err := engine.ParseAndExecute(scriptPath, vars)
+		// Change directory to project root before execution so relative paths work properly
+		originalDir, _ := os.Getwd()
+		os.Chdir(projectRoot)
+		defer os.Chdir(originalDir)
+
+		err = engine.ParseAndExecute(scriptPath, vars)
 		if err != nil {
 			return fmt.Errorf("script execution failed: %w", err)
 		}

--- a/internal/cli/new/cmd.go
+++ b/internal/cli/new/cmd.go
@@ -103,10 +103,20 @@ It looks for the script in the './bl/' folder of your current project.`,
 			fmt.Printf("Executing Boiler script: %s from %s\n", scriptPath, projectRoot)
 		}
 
-		// Change directory to project root before execution so relative paths work properly
-		originalDir, _ := os.Getwd()
-		os.Chdir(projectRoot)
-		defer os.Chdir(originalDir)
+		// Change directory to project root before execution so relative paths work properly.
+		// Both the switch and the restore must succeed to prevent files landing in the wrong tree.
+		originalDir, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to determine current directory: %w", err)
+		}
+		if err := os.Chdir(projectRoot); err != nil {
+			return fmt.Errorf("failed to switch to project root %q: %w", projectRoot, err)
+		}
+		defer func() {
+			if restoreErr := os.Chdir(originalDir); restoreErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to restore working directory to %q: %v\n", originalDir, restoreErr)
+			}
+		}()
 
 		err = engine.ParseAndExecute(scriptPath, vars)
 		if err != nil {

--- a/internal/cli/new/cmd.go
+++ b/internal/cli/new/cmd.go
@@ -49,8 +49,8 @@ It looks for the script in the './bl/' folder of your current project.`,
 		}
 
 		scriptName := args[0]
-		// In Boiler, local scripts are in the `bl/` directory of the project
-		scriptPath := filepath.Join("bl", scriptName+".bl")
+		// In Boiler, local scripts are in the `bl/commands/` directory of the project
+		scriptPath := filepath.Join("bl", "commands", scriptName+".bl")
 
 		if _, err := os.Stat(scriptPath); os.IsNotExist(err) {
 			return fmt.Errorf("script '%s' not found. Ensure '%s' exists in your project", scriptName, scriptPath)

--- a/internal/cli/new/cmd.go
+++ b/internal/cli/new/cmd.go
@@ -73,6 +73,19 @@ It looks for the script in the './bl/' folder of your current project.`,
 		vars := make(map[string]string)
 		positionalIndex := 1
 
+		// Seed vars from BOILER_VAR_* environment variables so that env-prefilled
+		// values are available during direct .bl script execution (create, inject, etc.)
+		// CLI args added below will override these if the same key is provided.
+		for _, env := range os.Environ() {
+			if strings.HasPrefix(env, "BOILER_VAR_") {
+				kv := strings.SplitN(env, "=", 2)
+				if len(kv) == 2 {
+					key := strings.ToLower(strings.TrimPrefix(kv[0], "BOILER_VAR_"))
+					vars[key] = kv[1]
+				}
+			}
+		}
+
 		for i := 1; i < len(args); i++ {
 			arg := args[i]
 

--- a/internal/cli/new/cmd.go
+++ b/internal/cli/new/cmd.go
@@ -81,6 +81,10 @@ It looks for the script in the './bl/' folder of your current project.`,
 				continue // skip global verbose flag
 			}
 
+			if arg == "--global" || arg == "--local" {
+				continue
+			}
+
 			if strings.HasPrefix(arg, "--") || strings.HasPrefix(arg, "-") {
 				// It's a flag
 				flagRaw := strings.TrimLeft(arg, "-")

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -75,7 +75,7 @@ variations of the same snippet or stack.`,
 		utils.ShowBanner()
 		utils.ShowQuickHelp()
 	},
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		if logger != nil {
 			logger.SetVerbose(verbose)
 		}
@@ -96,23 +96,24 @@ variations of the same snippet or stack.`,
 		if scope == config.ScopeLocal {
 			cwd, err := os.Getwd()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "warning: could not determine working directory for local scope: %v\n", err)
-			} else {
-				projectRoot := cwd // default: treat cwd as project root
-				nearestConfig, cfgErr := config.FindNearestConfig(cwd)
-				if cfgErr == nil && nearestConfig != "" {
-					projectRoot = filepath.Dir(nearestConfig)
-				}
-
-				localBoilerDir := filepath.Join(projectRoot, constants.LocalBoilerDirName) // <ProjectRoot>/bl
-
-				// Update runtime paths for this command execution
-				manager.Runtime.Paths.Root = localBoilerDir
-				manager.Runtime.Paths.Store = filepath.Join(localBoilerDir, constants.StoreDirName)
-				manager.Runtime.Paths.Snippets = filepath.Join(manager.Runtime.Paths.Store, constants.SnippetsDirName)
-				manager.Runtime.Paths.Stacks = filepath.Join(manager.Runtime.Paths.Store, constants.StacksDirName)
+				return fmt.Errorf("cannot resolve local scope: failed to determine working directory: %w", err)
 			}
+
+			projectRoot := cwd // default: treat cwd as project root
+			nearestConfig, cfgErr := config.FindNearestConfig(cwd)
+			if cfgErr == nil && nearestConfig != "" {
+				projectRoot = filepath.Dir(nearestConfig)
+			}
+
+			localBoilerDir := filepath.Join(projectRoot, constants.LocalBoilerDirName) // <ProjectRoot>/bl
+
+			// Update runtime paths for this command execution
+			manager.Runtime.Paths.Root = localBoilerDir
+			manager.Runtime.Paths.Store = filepath.Join(localBoilerDir, constants.StoreDirName)
+			manager.Runtime.Paths.Snippets = filepath.Join(manager.Runtime.Paths.Store, constants.SnippetsDirName)
+			manager.Runtime.Paths.Stacks = filepath.Join(manager.Runtime.Paths.Store, constants.StacksDirName)
 		}
+		return nil
 	},
 }
 

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"os"
+	"path/filepath"
 	"sync"
 
 	addcmd "github.com/rishiyaduwanshi/boiler/internal/cli/add"
@@ -23,6 +24,7 @@ import (
 	versioncmd "github.com/rishiyaduwanshi/boiler/internal/cli/version"
 
 	"github.com/rishiyaduwanshi/boiler/internal/config"
+	"github.com/rishiyaduwanshi/boiler/internal/constants"
 	"github.com/rishiyaduwanshi/boiler/internal/remote"
 	"github.com/rishiyaduwanshi/boiler/internal/utils"
 	"github.com/spf13/cobra"
@@ -78,10 +80,28 @@ variations of the same snippet or stack.`,
 		}
 		remote.SetVerbose(verbose)
 
+		scope := config.ResolveScope(manager, isGlobal, isLocal)
+
 		// Create the BoilerContext by resolving the current Scope
 		config.Ctx = &config.BoilerContext{
 			Manager: manager,
-			Scope:   config.ResolveScope(manager, isGlobal, isLocal),
+			Scope:   scope,
+		}
+
+		// Dynamically override paths to point to the local project store if scope is Local
+		if scope == config.ScopeLocal {
+			cwd, _ := os.Getwd()
+			nearestConfig, err := config.FindNearestConfig(cwd)
+			if err == nil && nearestConfig != "" {
+				projectRoot := filepath.Dir(nearestConfig)
+				localBoilerDir := filepath.Join(projectRoot, constants.BoilerDirName) // <ProjectRoot>/bl
+
+				// Update runtime paths for this command execution
+				manager.Runtime.Paths.Root = localBoilerDir
+				manager.Runtime.Paths.Store = filepath.Join(localBoilerDir, constants.StoreDirName)
+				manager.Runtime.Paths.Snippets = filepath.Join(manager.Runtime.Paths.Store, constants.SnippetsDirName)
+				manager.Runtime.Paths.Stacks = filepath.Join(manager.Runtime.Paths.Store, constants.StacksDirName)
+			}
 		}
 	},
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -88,12 +89,21 @@ variations of the same snippet or stack.`,
 			Scope:   scope,
 		}
 
-		// Dynamically override paths to point to the local project store if scope is Local
+		// Dynamically override paths to point to the local project store if scope is Local.
+		// If a boiler.local.json is found, use its directory as the project root.
+		// Otherwise fall back to cwd/bl/ so that --local works even in projects without
+		// a local config file — but never silently reuse the global ~/.boiler paths.
 		if scope == config.ScopeLocal {
-			cwd, _ := os.Getwd()
-			nearestConfig, err := config.FindNearestConfig(cwd)
-			if err == nil && nearestConfig != "" {
-				projectRoot := filepath.Dir(nearestConfig)
+			cwd, err := os.Getwd()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: could not determine working directory for local scope: %v\n", err)
+			} else {
+				projectRoot := cwd // default: treat cwd as project root
+				nearestConfig, cfgErr := config.FindNearestConfig(cwd)
+				if cfgErr == nil && nearestConfig != "" {
+					projectRoot = filepath.Dir(nearestConfig)
+				}
+
 				localBoilerDir := filepath.Join(projectRoot, constants.LocalBoilerDirName) // <ProjectRoot>/bl
 
 				// Update runtime paths for this command execution

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -11,6 +11,7 @@ import (
 	infocmd "github.com/rishiyaduwanshi/boiler/internal/cli/info"
 	initcmd "github.com/rishiyaduwanshi/boiler/internal/cli/init"
 	listcmd "github.com/rishiyaduwanshi/boiler/internal/cli/list"
+	newcmd "github.com/rishiyaduwanshi/boiler/internal/cli/new"
 	pathcmd "github.com/rishiyaduwanshi/boiler/internal/cli/path"
 	searchcmd "github.com/rishiyaduwanshi/boiler/internal/cli/search"
 	selfcmd "github.com/rishiyaduwanshi/boiler/internal/cli/self"
@@ -98,6 +99,7 @@ func Execute(m *config.Manager, log *utils.Logger) error {
 	infocmd.Setup(cfg, logger)
 	initcmd.Setup(cfg, logger)
 	listcmd.Setup(cfg, logger)
+	newcmd.Setup(cfg, logger)
 	pathcmd.Setup(cfg, logger)
 	searchcmd.Setup(cfg, logger)
 	selfcmd.Setup(cfg, logger)
@@ -149,6 +151,7 @@ func init() {
 	rootCmd.AddCommand(infocmd.Cmd)
 	rootCmd.AddCommand(searchcmd.Cmd)
 	rootCmd.AddCommand(initcmd.Cmd)
+	rootCmd.AddCommand(newcmd.Cmd)
 	rootCmd.AddCommand(pathcmd.Cmd)
 	rootCmd.AddCommand(selfcmd.Cmd)
 	rootCmd.AddCommand(usecmd.Cmd)

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -94,7 +94,7 @@ variations of the same snippet or stack.`,
 			nearestConfig, err := config.FindNearestConfig(cwd)
 			if err == nil && nearestConfig != "" {
 				projectRoot := filepath.Dir(nearestConfig)
-				localBoilerDir := filepath.Join(projectRoot, constants.BoilerDirName) // <ProjectRoot>/bl
+				localBoilerDir := filepath.Join(projectRoot, constants.LocalBoilerDirName) // <ProjectRoot>/bl
 
 				// Update runtime paths for this command execution
 				manager.Runtime.Paths.Root = localBoilerDir

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,9 +46,9 @@ func defaultEditor() string {
 func getRootPath() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return constants.BoilerDirName
+		return constants.GlobalBoilerDirName
 	}
-	return filepath.Join(home, constants.BoilerDirName)
+	return filepath.Join(home, constants.GlobalBoilerDirName)
 }
 
 func DefaultConfig() *Config {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,7 +37,7 @@ func TestDefaultConfig(t *testing.T) {
 		t.Error("Version should not be empty")
 	}
 
-	expectedRoot := filepath.Join(home, constants.BoilerDirName)
+	expectedRoot := filepath.Join(home, constants.GlobalBoilerDirName)
 	if cfg.Paths.Root != expectedRoot {
 		t.Errorf("Paths.Root = %q, want %q", cfg.Paths.Root, expectedRoot)
 	}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"maps"
 	"os"
+	"strings"
 
 	"github.com/rishiyaduwanshi/boiler/internal/utils"
 )
@@ -97,6 +98,21 @@ func mergeIntoRuntime(m *Manager) {
 				m.Runtime.Artifacts = make(map[string]string)
 			}
 			maps.Copy(m.Runtime.Artifacts, m.Local.Config.Artifacts)
+		}
+	}
+
+	// 4. Inject Environment Variables passed by scripts (e.g. BOILER_VAR_bl__name)
+	// We do this after loading from files so env vars take highest precedence
+	for _, envStr := range os.Environ() {
+		if strings.HasPrefix(envStr, "BOILER_VAR_") {
+			parts := strings.SplitN(envStr, "=", 2)
+			if len(parts) == 2 {
+				varName := strings.TrimPrefix(parts[0], "BOILER_VAR_")
+				if m.Runtime.Vars == nil {
+					m.Runtime.Vars = make(map[string]string)
+				}
+				m.Runtime.Vars[varName] = parts[1]
+			}
 		}
 	}
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"encoding/json"
+	"fmt"
 	"maps"
 	"os"
 	"strings"
@@ -23,10 +24,11 @@ func Load() (*Manager, error) {
 		manager.Global.Path = globalPath
 		if data, err := os.ReadFile(globalPath); err == nil {
 			var globalCfg Config
-			if err := json.Unmarshal(data, &globalCfg); err == nil {
-				manager.Global.Config = &globalCfg
-				manager.Global.Exists = true
+			if err := json.Unmarshal(data, &globalCfg); err != nil {
+				return nil, fmt.Errorf("failed to parse global config at %s: %w", globalPath, err)
 			}
+			manager.Global.Config = &globalCfg
+			manager.Global.Exists = true
 		}
 	}
 
@@ -38,10 +40,11 @@ func Load() (*Manager, error) {
 			manager.Local.Path = localPath
 			if data, err := os.ReadFile(localPath); err == nil {
 				var localCfg Config
-				if err := json.Unmarshal(data, &localCfg); err == nil {
-					manager.Local.Config = &localCfg
-					manager.Local.Exists = true
+				if err := json.Unmarshal(data, &localCfg); err != nil {
+					return nil, fmt.Errorf("failed to parse local config at %s: %w", localPath, err)
 				}
+				manager.Local.Config = &localCfg
+				manager.Local.Exists = true
 			}
 		} else {
 			// Initialize empty local config path for default saving

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -2,12 +2,13 @@ package constants
 
 const (
 	// Boiler Directories
-	BoilerDirName   = "bl"
-	StoreDirName    = "store"
-	SnippetsDirName = "snippets"
-	StacksDirName   = "stacks"
-	LogsDirName     = "logs"
-	BinDirName      = "bin"
+	GlobalBoilerDirName = ".boiler"
+	LocalBoilerDirName  = "bl"
+	StoreDirName        = "store"
+	SnippetsDirName     = "snippets"
+	StacksDirName       = "stacks"
+	LogsDirName         = "logs"
+	BinDirName          = "bin"
 
 	// Config Files
 	GlobalConfigFileName = "boiler.conf.json"

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -2,7 +2,7 @@ package constants
 
 const (
 	// Boiler Directories
-	BoilerDirName   = ".boiler"
+	BoilerDirName   = "bl"
 	StoreDirName    = "store"
 	SnippetsDirName = "snippets"
 	StacksDirName   = "stacks"

--- a/internal/engine/evaluator.go
+++ b/internal/engine/evaluator.go
@@ -1,0 +1,87 @@
+package engine
+
+import (
+	"strings"
+)
+
+// EvaluateCondition parses and evaluates a logical condition string without AST.
+// Supports: ==, !=, !, &&, || (Evaluated left-to-right, AND before OR, no brackets)
+func EvaluateCondition(cond string, vars map[string]string) bool {
+	if strings.TrimSpace(cond) == "" {
+		return false
+	}
+
+	// First split by OR (||)
+	orParts := strings.Split(cond, "||")
+	for _, orPart := range orParts {
+		// Inside each OR part, all AND (&&) parts must be true
+		andParts := strings.Split(orPart, "&&")
+		allAndsTrue := true
+
+		for _, andPart := range andParts {
+			andPart = strings.TrimSpace(andPart)
+			if andPart == "" {
+				continue
+			}
+			if !evaluateSingle(andPart, vars) {
+				allAndsTrue = false
+				break
+			}
+		}
+
+		// If all AND parts in this OR block were true, the whole expression is true
+		if allAndsTrue {
+			return true
+		}
+	}
+
+	return false
+}
+
+func evaluateSingle(cond string, vars map[string]string) bool {
+	cond = strings.TrimSpace(cond)
+
+	// Handle NOT operator
+	isNot := false
+	if strings.HasPrefix(cond, "!") {
+		isNot = true
+		cond = strings.TrimSpace(strings.TrimPrefix(cond, "!"))
+	}
+
+	result := false
+
+	// Handle Equality
+	if strings.Contains(cond, "==") {
+		parts := strings.SplitN(cond, "==", 2)
+		left := resolveVal(parts[0], vars)
+		right := resolveVal(parts[1], vars)
+		result = (left == right)
+	} else if strings.Contains(cond, "!=") {
+		parts := strings.SplitN(cond, "!=", 2)
+		left := resolveVal(parts[0], vars)
+		right := resolveVal(parts[1], vars)
+		result = (left != right)
+	} else {
+		// Just a boolean variable check, e.g., "bl__is_ts"
+		val := resolveVal(cond, vars)
+		val = strings.ToLower(val)
+		result = (val == "true" || val == "1" || val == "yes")
+	}
+
+	if isNot {
+		return !result
+	}
+	return result
+}
+
+func resolveVal(s string, vars map[string]string) string {
+	s = strings.TrimSpace(s)
+	// Remove surrounding quotes if present
+	s = strings.Trim(s, `"'`)
+
+	// If it's a variable reference (starts with bl__), resolve it including modifiers
+	if strings.HasPrefix(s, "bl__") {
+		return ResolveVariable(s, vars)
+	}
+	return s
+}

--- a/internal/engine/evaluator_test.go
+++ b/internal/engine/evaluator_test.go
@@ -31,8 +31,8 @@ func TestEvaluateCondition(t *testing.T) {
 		{"OR condition (true)", "bl__is_js || bl__db == mongodb", true},
 		{"OR condition (false)", "bl__is_js || bl__db == postgres", false},
 		{"Complex AND/OR", "bl__is_js && bl__port == 8080 || bl__db == mongodb", true}, // (false AND true) OR true = true
-		{"Variable with modifier", "bl__name.lowercase() == user", true},
-		{"Variable with modifier equality", "bl__name.lowercase() == bl__name.lowercase()", true},
+		{"Variable with modifier", "bl__name.lowerCase() == user", true},
+		{"Variable with modifier equality", "bl__name.lowerCase() == bl__name.lowerCase()", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/engine/evaluator_test.go
+++ b/internal/engine/evaluator_test.go
@@ -1,0 +1,46 @@
+package engine
+
+import (
+	"testing"
+)
+
+func TestEvaluateCondition(t *testing.T) {
+	vars := map[string]string{
+		"bl__is_ts": "true",
+		"bl__is_js": "false",
+		"bl__db":    "mongodb",
+		"bl__port":  "8080",
+		"bl__name":  "User",
+	}
+
+	tests := []struct {
+		name     string
+		cond     string
+		expected bool
+	}{
+		{"Empty condition", "", false},
+		{"Simple true boolean", "bl__is_ts", true},
+		{"Simple false boolean", "bl__is_js", false},
+		{"Equality check (string)", "bl__db == mongodb", true},
+		{"Equality check with quotes", "bl__db == \"mongodb\"", true},
+		{"Inequality check", "bl__port != 3000", true},
+		{"NOT true", "!bl__is_ts", false},
+		{"NOT false", "!bl__is_js", true},
+		{"AND condition (true)", "bl__is_ts && bl__db == mongodb", true},
+		{"AND condition (false)", "bl__is_ts && bl__db == postgres", false},
+		{"OR condition (true)", "bl__is_js || bl__db == mongodb", true},
+		{"OR condition (false)", "bl__is_js || bl__db == postgres", false},
+		{"Complex AND/OR", "bl__is_js && bl__port == 8080 || bl__db == mongodb", true}, // (false AND true) OR true = true
+		{"Variable with modifier", "bl__name.lowercase() == user", true},
+		{"Variable with modifier equality", "bl__name.lowercase() == bl__name.lowercase()", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := EvaluateCondition(tt.cond, vars)
+			if result != tt.expected {
+				t.Errorf("EvaluateCondition(%q) = %v; expected %v", tt.cond, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -102,21 +101,23 @@ func parseArgs(s string) []string {
 	return args
 }
 
-// executeOSCommand runs an OS command without injecting user-supplied arguments
-// into a shell string. On Unix, the executable is invoked directly (no shell).
-// On Windows, cmd /c is used with arguments passed separately, which avoids
-// the single-string injection risk while still supporting shell built-ins.
+// executeOSCommand invokes a real executable directly without involving any
+// shell interpreter. This prevents command injection on all platforms:
+// user-supplied template variables can never be interpreted as shell
+// metacharacters because no shell is involved in the execution.
+//
+// Note: shell built-ins (e.g. echo, dir, cd) are intentionally not supported.
+// .bl scripts should call real executables available in PATH (npm, git, go, etc.).
 func executeOSCommand(cmdStr string) error {
 	args := parseArgs(cmdStr)
 	if len(args) == 0 {
 		return fmt.Errorf("run: empty command")
 	}
-	var cmd *exec.Cmd
-	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", append([]string{"/c"}, args...)...)
-	} else {
-		cmd = exec.Command(args[0], args[1:]...)
+	exe, err := exec.LookPath(args[0])
+	if err != nil {
+		return fmt.Errorf("run: executable %q not found in PATH: %w", args[0], err)
 	}
+	cmd := exec.Command(exe, args[1:]...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	cmd.Stdin = os.Stdin

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -2,12 +2,25 @@ package engine
 
 import (
 	"fmt"
+	"strings"
 )
 
 // ExecuteCommand routes parsed Boiler commands to their respective actions.
 // Supports: use, run, inject
 func ExecuteCommand(commandLine string) error {
-	// Stub implementation for now until we build the actual executor and injector
-	fmt.Printf("[ENGINE EXEC] %s\n", commandLine)
-	return nil
+	commandLine = strings.TrimSpace(commandLine)
+
+	if strings.HasPrefix(commandLine, "inject ") {
+		return InjectCode(commandLine)
+	} else if strings.HasPrefix(commandLine, "use ") {
+		// TODO: Implement use command (copy files from repo)
+		fmt.Printf("[ENGINE EXEC] %s\n", commandLine)
+		return nil
+	} else if strings.HasPrefix(commandLine, "run ") {
+		// TODO: Implement run command (execute shell scripts or sub-boiler commands)
+		fmt.Printf("[ENGINE EXEC] %s\n", commandLine)
+		return nil
+	}
+
+	return fmt.Errorf("unknown command: %s", commandLine)
 }

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -18,11 +18,10 @@ func ExecuteCommand(state *ScriptState, commandLine string) error {
 	} else if strings.HasPrefix(commandLine, "create ") {
 		return CreateFile(commandLine)
 	} else if strings.HasPrefix(commandLine, "run ") {
-		// Run an arbitrary OS command (e.g. npm install)
-		cmdStr := strings.TrimPrefix(commandLine, "run ")
-		cmdStr = strings.TrimSpace(cmdStr)
+		// Raw (non-interpolated) run line: tokenize first, then interpolate per-token
+		cmdStr := strings.TrimSpace(strings.TrimPrefix(commandLine, "run "))
 		fmt.Printf("[ENGINE] Running OS command: %s\n", cmdStr)
-		return executeOSCommand(cmdStr)
+		return executeOSCommand(state, cmdStr)
 	} else {
 		// Assume it's a native Boiler command (use, add, var, alias, etc.)
 		exePath, err := os.Executable()
@@ -106,13 +105,28 @@ func parseArgs(s string) []string {
 // user-supplied template variables can never be interpreted as shell
 // metacharacters because no shell is involved in the execution.
 //
+// Variable values are interpolated PER TOKEN (after tokenization), so a value
+// like "left-pad --save-dev" remains a single argv entry and cannot inject flags.
+//
 // Note: shell built-ins (e.g. echo, dir, cd) are intentionally not supported.
 // .bl scripts should call real executables available in PATH (npm, git, go, etc.).
-func executeOSCommand(cmdStr string) error {
-	args := parseArgs(cmdStr)
-	if len(args) == 0 {
+func executeOSCommand(state *ScriptState, cmdStr string) error {
+	// Tokenize the template BEFORE variable substitution
+	templateArgs := parseArgs(cmdStr)
+	if len(templateArgs) == 0 {
 		return fmt.Errorf("run: empty command")
 	}
+
+	// Interpolate each token individually — variable values stay atomic
+	args := make([]string, len(templateArgs))
+	for i, arg := range templateArgs {
+		if state != nil {
+			args[i] = state.InterpolateVariables(arg)
+		} else {
+			args[i] = arg
+		}
+	}
+
 	exe, err := exec.LookPath(args[0])
 	if err != nil {
 		return fmt.Errorf("run: executable %q not found in PATH: %w", args[0], err)

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -31,8 +31,17 @@ func ExecuteCommand(state *ScriptState, commandLine string) error {
 
 		fmt.Printf("[ENGINE] Running Boiler command: %s %s\n", filepath.Base(exePath), commandLine)
 
-		// Bypass OS shell entirely for native commands to avoid quoting issues
-		args := parseArgs(commandLine)
+		// Tokenize the template FIRST, then interpolate each token individually.
+		// This keeps variable values (e.g. paths with spaces) as atomic arguments.
+		templateArgs := parseArgs(commandLine)
+		args := make([]string, len(templateArgs))
+		for i, arg := range templateArgs {
+			if state != nil {
+				args[i] = state.InterpolateVariables(arg)
+			} else {
+				args[i] = arg
+			}
+		}
 		cmd := exec.Command(exePath, args...)
 
 		// Attach standard streams so prompts and outputs work normally

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -56,21 +56,44 @@ func ExecuteCommand(state *ScriptState, commandLine string) error {
 	}
 }
 
-// parseArgs safely splits a command string by spaces, respecting double quotes.
+// parseArgs safely splits a command string by spaces, respecting both single
+// and double quotes, as well as backslash-escaped characters.
 func parseArgs(s string) []string {
 	var args []string
 	var current []rune
+	var quoteChar rune
 	inQuote := false
+	escaped := false
+
 	for _, r := range s {
-		if r == '"' {
-			inQuote = !inQuote
-		} else if r == ' ' && !inQuote {
-			if len(current) > 0 {
-				args = append(args, string(current))
-				current = []rune{}
+		if escaped {
+			current = append(current, r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if inQuote {
+			if r == quoteChar {
+				inQuote = false
+			} else {
+				current = append(current, r)
 			}
 		} else {
-			current = append(current, r)
+			switch r {
+			case '"', '\'':
+				inQuote = true
+				quoteChar = r
+			case ' ', '\t':
+				if len(current) > 0 {
+					args = append(args, string(current))
+					current = current[:0]
+				}
+			default:
+				current = append(current, r)
+			}
 		}
 	}
 	if len(current) > 0 {
@@ -79,15 +102,24 @@ func parseArgs(s string) []string {
 	return args
 }
 
+// executeOSCommand runs an OS command without injecting user-supplied arguments
+// into a shell string. On Unix, the executable is invoked directly (no shell).
+// On Windows, cmd /c is used with arguments passed separately, which avoids
+// the single-string injection risk while still supporting shell built-ins.
 func executeOSCommand(cmdStr string) error {
+	args := parseArgs(cmdStr)
+	if len(args) == 0 {
+		return fmt.Errorf("run: empty command")
+	}
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/c", cmdStr)
+		cmd = exec.Command("cmd", append([]string{"/c"}, args...)...)
 	} else {
-		cmd = exec.Command("sh", "-c", cmdStr)
+		cmd = exec.Command(args[0], args[1:]...)
 	}
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
+	cmd.Stdin = os.Stdin
 	return cmd.Run()
 }
 

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -2,6 +2,9 @@ package engine
 
 import (
 	"fmt"
+	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 )
 
@@ -12,15 +15,27 @@ func ExecuteCommand(commandLine string) error {
 
 	if strings.HasPrefix(commandLine, "inject ") {
 		return InjectCode(commandLine)
-	} else if strings.HasPrefix(commandLine, "use ") {
-		// TODO: Implement use command (copy files from repo)
-		fmt.Printf("[ENGINE EXEC] %s\n", commandLine)
-		return nil
 	} else if strings.HasPrefix(commandLine, "run ") {
-		// TODO: Implement run command (execute shell scripts or sub-boiler commands)
-		fmt.Printf("[ENGINE EXEC] %s\n", commandLine)
-		return nil
+		// Run an arbitrary OS command (e.g. npm install)
+		cmdStr := strings.TrimPrefix(commandLine, "run ")
+		cmdStr = strings.TrimSpace(cmdStr)
+		fmt.Printf("[ENGINE] Running OS command: %s\n", cmdStr)
+		return executeOSCommand(cmdStr)
+	} else {
+		// Assume it's a native Boiler command (use, add, var, alias, etc.)
+		fmt.Printf("[ENGINE] Running Boiler command: bl %s\n", commandLine)
+		return executeOSCommand("bl " + commandLine)
 	}
+}
 
-	return fmt.Errorf("unknown command: %s", commandLine)
+func executeOSCommand(cmdStr string) error {
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", cmdStr)
+	} else {
+		cmd = exec.Command("sh", "-c", cmdStr)
+	}
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 )
@@ -15,6 +16,8 @@ func ExecuteCommand(commandLine string) error {
 
 	if strings.HasPrefix(commandLine, "inject ") {
 		return InjectCode(commandLine)
+	} else if strings.HasPrefix(commandLine, "create ") {
+		return CreateFile(commandLine)
 	} else if strings.HasPrefix(commandLine, "run ") {
 		// Run an arbitrary OS command (e.g. npm install)
 		cmdStr := strings.TrimPrefix(commandLine, "run ")
@@ -23,9 +26,43 @@ func ExecuteCommand(commandLine string) error {
 		return executeOSCommand(cmdStr)
 	} else {
 		// Assume it's a native Boiler command (use, add, var, alias, etc.)
-		fmt.Printf("[ENGINE] Running Boiler command: bl %s\n", commandLine)
-		return executeOSCommand("bl " + commandLine)
+		exePath, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("failed to resolve boiler executable: %w", err)
+		}
+
+		fmt.Printf("[ENGINE] Running Boiler command: %s %s\n", filepath.Base(exePath), commandLine)
+
+		// Bypass OS shell entirely for native commands to avoid quoting issues
+		args := parseArgs(commandLine)
+		cmd := exec.Command(exePath, args...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		return cmd.Run()
 	}
+}
+
+// parseArgs safely splits a command string by spaces, respecting double quotes.
+func parseArgs(s string) []string {
+	var args []string
+	var current []rune
+	inQuote := false
+	for _, r := range s {
+		if r == '"' {
+			inQuote = !inQuote
+		} else if r == ' ' && !inQuote {
+			if len(current) > 0 {
+				args = append(args, string(current))
+				current = []rune{}
+			}
+		} else {
+			current = append(current, r)
+		}
+	}
+	if len(current) > 0 {
+		args = append(args, string(current))
+	}
+	return args
 }
 
 func executeOSCommand(cmdStr string) error {
@@ -38,4 +75,31 @@ func executeOSCommand(cmdStr string) error {
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
+}
+
+// CreateFile parses a create command and writes the multiline content to a new file.
+func CreateFile(cmd string) error {
+	// Extract content from backticks
+	parts := strings.SplitN(cmd, "`", 3)
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid create command: missing or unclosed backticks for content")
+	}
+	content := parts[1]
+
+	// Parse the rest of the command
+	cmdWithoutContent := strings.TrimSpace(parts[0])
+	tokens := strings.Fields(cmdWithoutContent)
+	if len(tokens) < 2 {
+		return fmt.Errorf("invalid create command: missing target file")
+	}
+
+	filePath := tokens[1]
+
+	// Create directory if it doesn't exist
+	dir := filepath.Dir(filePath)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("failed to create directories for %s: %w", filePath, err)
+	}
+
+	return os.WriteFile(filePath, []byte(strings.TrimPrefix(content, "\n")), 0644)
 }

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -1,0 +1,13 @@
+package engine
+
+import (
+	"fmt"
+)
+
+// ExecuteCommand routes parsed Boiler commands to their respective actions.
+// Supports: use, run, inject
+func ExecuteCommand(commandLine string) error {
+	// Stub implementation for now until we build the actual executor and injector
+	fmt.Printf("[ENGINE EXEC] %s\n", commandLine)
+	return nil
+}

--- a/internal/engine/executor.go
+++ b/internal/engine/executor.go
@@ -11,7 +11,7 @@ import (
 
 // ExecuteCommand routes parsed Boiler commands to their respective actions.
 // Supports: use, run, inject
-func ExecuteCommand(commandLine string) error {
+func ExecuteCommand(state *ScriptState, commandLine string) error {
 	commandLine = strings.TrimSpace(commandLine)
 
 	if strings.HasPrefix(commandLine, "inject ") {
@@ -36,8 +36,22 @@ func ExecuteCommand(commandLine string) error {
 		// Bypass OS shell entirely for native commands to avoid quoting issues
 		args := parseArgs(commandLine)
 		cmd := exec.Command(exePath, args...)
+
+		// Attach standard streams so prompts and outputs work normally
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
+
+		// Pass ALL script variables to the child process via Environment Variables
+		// We prefix them with BOILER_VAR_ so the child process's config loader can pick them up.
+		cmd.Env = os.Environ()
+		if state != nil && state.Vars != nil {
+			for k, v := range state.Vars {
+				envKey := fmt.Sprintf("BOILER_VAR_%s", k)
+				cmd.Env = append(cmd.Env, fmt.Sprintf("%s=%s", envKey, v))
+			}
+		}
+
 		return cmd.Run()
 	}
 }

--- a/internal/engine/injector.go
+++ b/internal/engine/injector.go
@@ -1,0 +1,101 @@
+package engine
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// InjectCode parses an inject command and modifies the target file safely using markers.
+func InjectCode(cmd string) error {
+	// 1. Extract content from backticks
+	parts := strings.SplitN(cmd, "`", 3)
+	if len(parts) != 3 {
+		return fmt.Errorf("invalid inject command: missing or unclosed backticks for content")
+	}
+	content := parts[1]
+
+	// 2. Parse the rest of the command before the backticks
+	cmdWithoutContent := strings.TrimSpace(parts[0])
+
+	tokens := strings.Fields(cmdWithoutContent)
+	if len(tokens) < 2 {
+		return fmt.Errorf("invalid inject command: missing target file")
+	}
+
+	filePath := tokens[1]
+	detector := ""
+	appendMode := true // Default to append mode
+
+	for i := 2; i < len(tokens); i++ {
+		tok := tokens[i]
+		if tok == "-d" || tok == "--detect" {
+			if i+1 < len(tokens) {
+				detector = tokens[i+1]
+				i++
+			}
+		} else if tok == "-a" || tok == "--append" {
+			appendMode = true
+		} else if tok == "-p" || tok == "--prepend" {
+			appendMode = false
+		} else if tok == "-c" || tok == "--content" {
+			// Content is parsed via backticks, so ignore the flag itself
+		}
+	}
+
+	if detector == "" {
+		return fmt.Errorf("missing detector name (-d or --detect) in inject command")
+	}
+
+	return PerformInjection(filePath, detector, content, appendMode)
+}
+
+// PerformInjection finds the START/END markers in a file and injects the content.
+func PerformInjection(filePath, detector, content string, appendMode bool) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open target file for injection: %w", err)
+	}
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+	file.Close()
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read target file: %w", err)
+	}
+
+	startMarker := fmt.Sprintf("bl__DETECTOR_START_%s", detector)
+	endMarker := fmt.Sprintf("bl__DETECTOR_END_%s", detector)
+
+	var newLines []string
+	injected := false
+	contentLines := strings.Split(strings.Trim(content, "\r\n"), "\n")
+
+	for _, line := range lines {
+		// If appending, inject the content JUST BEFORE the END marker
+		if !injected && appendMode && strings.Contains(line, endMarker) {
+			newLines = append(newLines, contentLines...)
+			injected = true
+		}
+
+		newLines = append(newLines, line)
+
+		// If prepending, inject the content JUST AFTER the START marker
+		if !injected && !appendMode && strings.Contains(line, startMarker) {
+			newLines = append(newLines, contentLines...)
+			injected = true
+		}
+	}
+
+	if !injected {
+		return fmt.Errorf("detector markers for '%s' not found in %s", detector, filePath)
+	}
+
+	out := strings.Join(newLines, "\n") + "\n"
+	return os.WriteFile(filePath, []byte(out), 0644)
+}

--- a/internal/engine/injector_test.go
+++ b/internal/engine/injector_test.go
@@ -1,0 +1,66 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestInjectCode(t *testing.T) {
+	tempDir := t.TempDir()
+	targetFile := filepath.Join(tempDir, "routes.js")
+
+	initialContent := `import express from "express";
+const router = express.Router();
+
+// bl__DETECTOR_START_routes
+// bl__DETECTOR_END_routes
+
+export default router;
+`
+	err := os.WriteFile(targetFile, []byte(initialContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write target file: %v", err)
+	}
+
+	// Test 1: Append
+	appendCmd := "inject " + targetFile + " -d routes -a -c `\nrouter.use('/append', appendRouter);\n`"
+	err = InjectCode(appendCmd)
+	if err != nil {
+		t.Fatalf("InjectCode(append) failed: %v", err)
+	}
+
+	// Test 2: Prepend
+	prependCmd := "inject " + targetFile + " --detect routes --prepend --content `\nrouter.use('/prepend', prependRouter);\n`"
+	err = InjectCode(prependCmd)
+	if err != nil {
+		t.Fatalf("InjectCode(prepend) failed: %v", err)
+	}
+
+	// Read the file and verify
+	finalContentBytes, _ := os.ReadFile(targetFile)
+	finalContent := string(finalContentBytes)
+
+	expectedPrepend := "router.use('/prepend', prependRouter);"
+	expectedAppend := "router.use('/append', appendRouter);"
+
+	// Check if prepend is immediately after START marker
+	// Check if append is immediately before END marker
+	// Actually we just check if both strings are in the file in the correct order
+
+	if !strings.Contains(finalContent, expectedPrepend) {
+		t.Errorf("Prepend content not found in file")
+	}
+	if !strings.Contains(finalContent, expectedAppend) {
+		t.Errorf("Append content not found in file")
+	}
+
+	// Prepend should come before Append in the file
+	prependIdx := strings.Index(finalContent, expectedPrepend)
+	appendIdx := strings.Index(finalContent, expectedAppend)
+
+	if prependIdx > appendIdx {
+		t.Errorf("Prepend content is located AFTER append content, which is incorrect")
+	}
+}

--- a/internal/engine/modifiers.go
+++ b/internal/engine/modifiers.go
@@ -39,3 +39,23 @@ func ApplyModifiers(value string, modifiers []string) string {
 	}
 	return value
 }
+
+// ResolveVariable takes an expression like "bl__1.capitalize().snake_case()"
+// and a map of variables, looks up the base variable, and applies all modifiers.
+func ResolveVariable(expr string, vars map[string]string) string {
+	expr = strings.TrimSpace(expr)
+	parts := strings.Split(expr, ".")
+
+	baseVarName := parts[0]
+	val := vars[baseVarName]
+
+	if len(parts) > 1 {
+		// Remove empty parenthesis from modifiers if present (e.g., .capitalize() -> capitalize)
+		modifiers := make([]string, len(parts)-1)
+		for i, mod := range parts[1:] {
+			modifiers[i] = strings.TrimSuffix(mod, "()")
+		}
+		val = ApplyModifiers(val, modifiers)
+	}
+	return val
+}

--- a/internal/engine/modifiers.go
+++ b/internal/engine/modifiers.go
@@ -1,0 +1,41 @@
+package engine
+
+import (
+	"strings"
+
+	"github.com/rishiyaduwanshi/boiler/internal/utils"
+)
+
+// ApplyModifiers takes a base string value and applies a list of modifiers in order.
+// Modifiers are applied sequentially.
+// Example: value="hello world", modifiers=["camelCase", "capitalize"]
+func ApplyModifiers(value string, modifiers []string) string {
+	if len(modifiers) == 0 {
+		return value
+	}
+
+	for _, mod := range modifiers {
+		mod = strings.TrimSpace(mod)
+		switch mod {
+		case "capitalize", "capitalise":
+			value = utils.Capitalize(value)
+		case "lowercase", "toLowerCase", "to_lower_case":
+			value = utils.Lowercase(value)
+		case "uppercase", "toUpperCase", "to_upper_case":
+			value = utils.Uppercase(value)
+		case "title", "titleCase", "title_case":
+			value = utils.Title(value)
+		case "camel_case", "camelCase":
+			value = utils.CamelCase(value)
+		case "pascal_case", "pascalCase", "PascalCase":
+			value = utils.PascalCase(value)
+		case "snake_case", "snakeCase":
+			value = utils.SnakeCase(value)
+		case "kebab_case", "kebabCase":
+			value = utils.KebabCase(value)
+			// We can easily add has_flag, is_empty here if they return strings,
+			// but boolean helpers are usually evaluated in conditions, not string modifiers.
+		}
+	}
+	return value
+}

--- a/internal/engine/modifiers.go
+++ b/internal/engine/modifiers.go
@@ -19,19 +19,19 @@ func ApplyModifiers(value string, modifiers []string) string {
 		switch mod {
 		case "capitalize", "capitalise":
 			value = utils.Capitalize(value)
-		case "lowercase", "toLowerCase", "to_lower_case":
+		case "lower", "lowerCase", "lower_case":
 			value = utils.Lowercase(value)
-		case "uppercase", "toUpperCase", "to_upper_case":
+		case "upper", "upperCase", "upper_case":
 			value = utils.Uppercase(value)
 		case "title", "titleCase", "title_case":
 			value = utils.Title(value)
-		case "camel_case", "camelCase":
+		case "camelCase", "camel_case":
 			value = utils.CamelCase(value)
-		case "pascal_case", "pascalCase", "PascalCase":
+		case "pascalCase", "pascal_case":
 			value = utils.PascalCase(value)
-		case "snake_case", "snakeCase":
+		case "snakeCase", "snake_case":
 			value = utils.SnakeCase(value)
-		case "kebab_case", "kebabCase":
+		case "kebabCase", "kebab_case":
 			value = utils.KebabCase(value)
 			// We can easily add has_flag, is_empty here if they return strings,
 			// but boolean helpers are usually evaluated in conditions, not string modifiers.

--- a/internal/engine/modifiers_test.go
+++ b/internal/engine/modifiers_test.go
@@ -20,13 +20,13 @@ func TestApplyModifiers(t *testing.T) {
 		{
 			name:      "Lowercase",
 			value:     "Hello World",
-			modifiers: []string{"lowercase"},
+			modifiers: []string{"lowerCase"},
 			expected:  "hello world",
 		},
 		{
 			name:      "Uppercase",
 			value:     "hello world",
-			modifiers: []string{"uppercase"},
+			modifiers: []string{"upperCase"},
 			expected:  "HELLO WORLD",
 		},
 		{
@@ -74,7 +74,7 @@ func TestApplyModifiers(t *testing.T) {
 		{
 			name:      "Multiple Modifiers (snake_case -> uppercase)",
 			value:     "myAwesomeRoute",
-			modifiers: []string{"snake_case", "uppercase"},
+			modifiers: []string{"snake_case", "upperCase"},
 			expected:  "MY_AWESOME_ROUTE",
 		},
 		{

--- a/internal/engine/modifiers_test.go
+++ b/internal/engine/modifiers_test.go
@@ -1,0 +1,96 @@
+package engine
+
+import (
+	"testing"
+)
+
+func TestApplyModifiers(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		modifiers []string
+		expected  string
+	}{
+		{
+			name:      "No modifiers",
+			value:     "hello world",
+			modifiers: []string{},
+			expected:  "hello world",
+		},
+		{
+			name:      "Lowercase",
+			value:     "Hello World",
+			modifiers: []string{"lowercase"},
+			expected:  "hello world",
+		},
+		{
+			name:      "Uppercase",
+			value:     "hello world",
+			modifiers: []string{"uppercase"},
+			expected:  "HELLO WORLD",
+		},
+		{
+			name:      "Capitalize",
+			value:     "hello world",
+			modifiers: []string{"capitalize"},
+			expected:  "Hello world",
+		},
+		{
+			name:      "Capitalize with alias",
+			value:     "hello world",
+			modifiers: []string{"capitalise"},
+			expected:  "Hello world",
+		},
+		{
+			name:      "Snake Case",
+			value:     "HelloWorld",
+			modifiers: []string{"snake_case"},
+			expected:  "hello_world",
+		},
+		{
+			name:      "Snake Case with alias",
+			value:     "HelloWorld",
+			modifiers: []string{"snakeCase"},
+			expected:  "hello_world",
+		},
+		{
+			name:      "Camel Case",
+			value:     "hello-world",
+			modifiers: []string{"camel_case"},
+			expected:  "helloWorld",
+		},
+		{
+			name:      "Kebab Case",
+			value:     "HelloWorld",
+			modifiers: []string{"kebab_case"},
+			expected:  "hello-world",
+		},
+		{
+			name:      "Multiple Modifiers (camelCase -> pascalCase)",
+			value:     "my-awesome-route",
+			modifiers: []string{"camelCase", "pascalCase"},
+			expected:  "MyAwesomeRoute",
+		},
+		{
+			name:      "Multiple Modifiers (snake_case -> uppercase)",
+			value:     "myAwesomeRoute",
+			modifiers: []string{"snake_case", "uppercase"},
+			expected:  "MY_AWESOME_ROUTE",
+		},
+		{
+			name:      "Unknown Modifier (should be ignored)",
+			value:     "hello",
+			modifiers: []string{"unknown_format", "capitalize"},
+			expected:  "Hello",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ApplyModifiers(tt.value, tt.modifiers)
+			if result != tt.expected {
+				t.Errorf("ApplyModifiers(%q, %v) = %q; expected %q", tt.value, tt.modifiers, result, tt.expected)
+			}
+		})
+	}
+}

--- a/internal/engine/parser.go
+++ b/internal/engine/parser.go
@@ -1,0 +1,201 @@
+package engine
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+)
+
+// ScriptState holds the execution context of a .bl script.
+type ScriptState struct {
+	Vars      map[string]string
+	SkipStack []bool // Keeps track of `#if` and `#else` skipping logic
+}
+
+// isSkipping returns true if any block in the SkipStack is currently false.
+func (s *ScriptState) isSkipping() bool {
+	for _, shouldExecute := range s.SkipStack {
+		if !shouldExecute {
+			return true
+		}
+	}
+	return false
+}
+
+// varInterpolationRe matches variable references like bl__foo, bl__foo.capitalize(), etc.
+// It explicitly looks for () at the end of modifiers so it doesn't match file extensions like .js
+var varInterpolationRe = regexp.MustCompile(`(bl__[a-zA-Z0-9_]+(?:\.[a-zA-Z0-9_]+\(\))*)`)
+
+// InterpolateVariables replaces bl__ variables in a string with their actual values.
+func (s *ScriptState) InterpolateVariables(line string) string {
+	return varInterpolationRe.ReplaceAllStringFunc(line, func(match string) string {
+		return ResolveVariable(match, s.Vars)
+	})
+}
+
+// ParseAndExecute reads a .bl file and executes it line-by-line.
+func ParseAndExecute(filePath string, initialVars map[string]string) error {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return fmt.Errorf("failed to open script %s: %w", filePath, err)
+	}
+	defer file.Close()
+
+	state := &ScriptState{
+		Vars:      make(map[string]string),
+		SkipStack: make([]bool, 0),
+	}
+
+	for k, v := range initialVars {
+		state.Vars[k] = v
+	}
+
+	scanner := bufio.NewScanner(file)
+
+	inBacktick := false
+	var backtickContent strings.Builder
+	var backtickCommand string
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		rawLine := scanner.Text()
+
+		if inBacktick {
+			if strings.Contains(rawLine, "`") {
+				parts := strings.SplitN(rawLine, "`", 2)
+				backtickContent.WriteString(parts[0])
+				inBacktick = false
+
+				fullCommand := backtickCommand + "`" + backtickContent.String() + "`" + parts[1]
+				if err := executeLine(state, fullCommand, lineNumber); err != nil {
+					return err
+				}
+				backtickContent.Reset()
+			} else {
+				backtickContent.WriteString(rawLine + "\n")
+			}
+			continue
+		}
+
+		line := strings.TrimSpace(rawLine)
+
+		// Ignore empty lines and pure comments (not starting with #if, #else, #endif)
+		if line == "" || (strings.HasPrefix(line, "#") && !strings.HasPrefix(line, "#if") && !strings.HasPrefix(line, "#else") && !strings.HasPrefix(line, "#endif")) {
+			continue
+		}
+
+		// Handle control flow (evaluated even when skipping to maintain stack)
+		if strings.HasPrefix(line, "#if ") {
+			cond := strings.TrimSpace(strings.TrimPrefix(line, "#if "))
+			shouldExecute := EvaluateCondition(cond, state.Vars)
+
+			if state.isSkipping() {
+				shouldExecute = false
+			}
+			state.SkipStack = append(state.SkipStack, shouldExecute)
+			continue
+		} else if strings.HasPrefix(line, "#else") {
+			if len(state.SkipStack) == 0 {
+				return fmt.Errorf("error at line %d: #else without #if", lineNumber)
+			}
+
+			parentSkipping := false
+			if len(state.SkipStack) > 1 {
+				for _, p := range state.SkipStack[:len(state.SkipStack)-1] {
+					if !p {
+						parentSkipping = true
+						break
+					}
+				}
+			}
+
+			curr := state.SkipStack[len(state.SkipStack)-1]
+			if parentSkipping {
+				state.SkipStack[len(state.SkipStack)-1] = false
+			} else {
+				state.SkipStack[len(state.SkipStack)-1] = !curr
+			}
+			continue
+		} else if strings.HasPrefix(line, "#endif") {
+			if len(state.SkipStack) == 0 {
+				return fmt.Errorf("error at line %d: #endif without #if", lineNumber)
+			}
+			state.SkipStack = state.SkipStack[:len(state.SkipStack)-1]
+			continue
+		}
+
+		if state.isSkipping() {
+			continue
+		}
+
+		// Check if line starts a backtick block
+		if strings.Contains(line, "`") {
+			parts := strings.SplitN(line, "`", 2)
+			backtickCommand = parts[0]
+
+			if strings.Contains(parts[1], "`") {
+				// Backticks open and close on the same line, just execute normally
+			} else {
+				inBacktick = true
+				backtickContent.WriteString(parts[1] + "\n")
+				continue
+			}
+		}
+
+		if err := executeLine(state, line, lineNumber); err != nil {
+			return err
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("failed to read script: %w", err)
+	}
+
+	if len(state.SkipStack) > 0 {
+		return fmt.Errorf("unclosed #if block at end of file")
+	}
+	if inBacktick {
+		return fmt.Errorf("unclosed backtick block at end of file")
+	}
+
+	return nil
+}
+
+func executeLine(state *ScriptState, line string, lineNumber int) error {
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return nil
+	}
+
+	// Handle variable assignment FIRST, before general interpolation
+	if strings.HasPrefix(line, "__var ") {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			varName := strings.TrimSpace(strings.TrimPrefix(parts[0], "__var "))
+
+			// Interpolate the RIGHT side only
+			varValue := state.InterpolateVariables(strings.TrimSpace(parts[1]))
+			varValue = strings.Trim(varValue, `"'`)
+
+			state.Vars[varName] = varValue
+		}
+		return nil
+	}
+
+	// Interpolate variables for all other executable lines
+	line = state.InterpolateVariables(line)
+
+	// Handle metadata (ignore for execution, just store if needed)
+	if strings.HasPrefix(line, "__") {
+		return nil
+	}
+
+	// Execute command
+	if err := ExecuteCommand(line); err != nil {
+		return fmt.Errorf("error at line %d: %w", lineNumber, err)
+	}
+	return nil
+}

--- a/internal/engine/parser.go
+++ b/internal/engine/parser.go
@@ -185,10 +185,14 @@ func executeLine(state *ScriptState, line string, lineNumber int) error {
 		return nil
 	}
 
-	// For 'run' commands, skip pre-interpolation so each token is interpolated
-	// individually inside executeOSCommand. This prevents user-supplied variable
-	// values from being re-tokenized and injecting extra flags.
-	if strings.HasPrefix(line, "run ") {
+	// For 'run' and native Boiler commands, skip pre-interpolation so each
+	// token is interpolated individually inside ExecuteCommand.
+	// 'create' and 'inject' still use string interpolation because their
+	// multi-line backtick content also requires variable substitution.
+	isNative := !strings.HasPrefix(line, "create ") &&
+		!strings.HasPrefix(line, "inject ") &&
+		!strings.HasPrefix(line, "__")
+	if isNative {
 		if err := ExecuteCommand(state, line); err != nil {
 			return fmt.Errorf("error at line %d: %w", lineNumber, err)
 		}

--- a/internal/engine/parser.go
+++ b/internal/engine/parser.go
@@ -185,6 +185,16 @@ func executeLine(state *ScriptState, line string, lineNumber int) error {
 		return nil
 	}
 
+	// For 'run' commands, skip pre-interpolation so each token is interpolated
+	// individually inside executeOSCommand. This prevents user-supplied variable
+	// values from being re-tokenized and injecting extra flags.
+	if strings.HasPrefix(line, "run ") {
+		if err := ExecuteCommand(state, line); err != nil {
+			return fmt.Errorf("error at line %d: %w", lineNumber, err)
+		}
+		return nil
+	}
+
 	// Interpolate variables for all other executable lines
 	line = state.InterpolateVariables(line)
 

--- a/internal/engine/parser.go
+++ b/internal/engine/parser.go
@@ -194,7 +194,7 @@ func executeLine(state *ScriptState, line string, lineNumber int) error {
 	}
 
 	// Execute command
-	if err := ExecuteCommand(line); err != nil {
+	if err := ExecuteCommand(state, line); err != nil {
 		return fmt.Errorf("error at line %d: %w", lineNumber, err)
 	}
 	return nil

--- a/internal/engine/parser_test.go
+++ b/internal/engine/parser_test.go
@@ -67,7 +67,7 @@ func TestInterpolateVariables(t *testing.T) {
 		{"run echo bl__foo", "run echo hello world"},
 		{"run echo bl__foo.capitalize()", "run echo Hello world"},
 		{"run echo bl__foo.snake_case()", "run echo hello_world"},
-		{"run echo bl__foo.snake_case().uppercase()", "run echo HELLO_WORLD"},
+		{"run echo bl__foo.snake_case().upperCase()", "run echo HELLO_WORLD"},
 		{"use repo:file.js ./src/bl__foo.snake_case().js", "use repo:file.js ./src/hello_world.js"},
 	}
 

--- a/internal/engine/parser_test.go
+++ b/internal/engine/parser_test.go
@@ -1,0 +1,75 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseAndExecute(t *testing.T) {
+	// We will create a temporary .bl file to parse and test
+	tempDir := t.TempDir()
+	scriptPath := filepath.Join(tempDir, "test.bl")
+
+	scriptContent := `
+__desc = "Test Script"
+__var bl__name = bl__1.capitalize()
+__var bl__is_ts = true
+
+#if bl__is_ts
+	run echo "using TS for bl__name"
+	#if bl__name == "Abhinav"
+		run echo "Hello Abhinav"
+	#endif
+#else
+	run echo "using JS"
+#endif
+
+# Test backticks
+inject ./file.js --content ` + "`" + `
+console.log("bl__name");
+` + "`" + `
+`
+	err := os.WriteFile(scriptPath, []byte(scriptContent), 0644)
+	if err != nil {
+		t.Fatalf("Failed to write test script: %v", err)
+	}
+
+	initialVars := map[string]string{
+		"bl__1": "abhinav", // will be capitalized to "Abhinav"
+	}
+
+	// This should run without returning errors.
+	// Since ExecuteCommand is currently a stub that prints to stdout,
+	// we just test if the parser correctly evaluates the logic without crashing.
+	err = ParseAndExecute(scriptPath, initialVars)
+	if err != nil {
+		t.Fatalf("ParseAndExecute failed: %v", err)
+	}
+}
+
+func TestInterpolateVariables(t *testing.T) {
+	state := &ScriptState{
+		Vars: map[string]string{
+			"bl__foo": "hello world",
+		},
+	}
+
+	tests := []struct {
+		line     string
+		expected string
+	}{
+		{"run echo bl__foo", "run echo hello world"},
+		{"run echo bl__foo.capitalize()", "run echo Hello world"},
+		{"run echo bl__foo.snake_case()", "run echo hello_world"},
+		{"run echo bl__foo.snake_case().uppercase()", "run echo HELLO_WORLD"},
+		{"use repo:file.js ./src/bl__foo.snake_case().js", "use repo:file.js ./src/hello_world.js"},
+	}
+
+	for _, tt := range tests {
+		result := state.InterpolateVariables(tt.line)
+		if result != tt.expected {
+			t.Errorf("Interpolate(%q) = %q; expected %q", tt.line, result, tt.expected)
+		}
+	}
+}

--- a/internal/engine/parser_test.go
+++ b/internal/engine/parser_test.go
@@ -11,6 +11,10 @@ func TestParseAndExecute(t *testing.T) {
 	tempDir := t.TempDir()
 	scriptPath := filepath.Join(tempDir, "test.bl")
 
+	dummyJsPath := filepath.Join(tempDir, "file.js")
+	// Create dummy file for injection
+	os.WriteFile(dummyJsPath, []byte("// bl__DETECTOR_START_test\n// bl__DETECTOR_END_test\n"), 0644)
+
 	scriptContent := `
 __desc = "Test Script"
 __var bl__name = bl__1.capitalize()
@@ -26,7 +30,7 @@ __var bl__is_ts = true
 #endif
 
 # Test backticks
-inject ./file.js --content ` + "`" + `
+inject ` + filepath.ToSlash(dummyJsPath) + ` -d test -a -c ` + "`" + `
 console.log("bl__name");
 ` + "`" + `
 `

--- a/internal/engine/parser_test.go
+++ b/internal/engine/parser_test.go
@@ -13,7 +13,9 @@ func TestParseAndExecute(t *testing.T) {
 
 	dummyJsPath := filepath.Join(tempDir, "file.js")
 	// Create dummy file for injection
-	os.WriteFile(dummyJsPath, []byte("// bl__DETECTOR_START_test\n// bl__DETECTOR_END_test\n"), 0644)
+	if err := os.WriteFile(dummyJsPath, []byte("// bl__DETECTOR_START_test\n// bl__DETECTOR_END_test\n"), 0644); err != nil {
+		t.Fatalf("Failed to write dummy JS file: %v", err)
+	}
 
 	scriptContent := `
 __desc = "Test Script"
@@ -21,12 +23,12 @@ __var bl__name = bl__1.capitalize()
 __var bl__is_ts = true
 
 #if bl__is_ts
-	run echo "using TS for bl__name"
+	run go env GOPATH
 	#if bl__name == "Abhinav"
-		run echo "Hello Abhinav"
+		run go env GOOS
 	#endif
 #else
-	run echo "using JS"
+	run go env GOARCH
 #endif
 
 # Test backticks
@@ -43,9 +45,8 @@ console.log("bl__name");
 		"bl__1": "abhinav", // will be capitalized to "Abhinav"
 	}
 
-	// This should run without returning errors.
-	// Since ExecuteCommand is currently a stub that prints to stdout,
-	// we just test if the parser correctly evaluates the logic without crashing.
+	// ParseAndExecute should run without errors: variables resolved,
+	// conditionals evaluated, inject applied, and OS commands executed.
 	err = ParseAndExecute(scriptPath, initialVars)
 	if err != nil {
 		t.Fatalf("ParseAndExecute failed: %v", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -81,23 +81,73 @@ func (s *Store) GetMeta() *Meta {
 }
 
 func (s *Store) AddSnippet(name, path string) error {
-	s.meta.Snippets[name] = path
+	if rel, err := filepath.Rel(filepath.Dir(s.metaPath), path); err == nil {
+		path = rel
+	}
+	s.meta.Snippets[name] = filepath.ToSlash(path)
 	return s.Save()
 }
 
 func (s *Store) AddStack(name, path string) error {
-	s.meta.Stacks[name] = path
+	if rel, err := filepath.Rel(filepath.Dir(s.metaPath), path); err == nil {
+		path = rel
+	}
+	s.meta.Stacks[name] = filepath.ToSlash(path)
 	return s.Save()
+}
+
+func (s *Store) resolvePath(p string) string {
+	if filepath.IsAbs(p) {
+		return p
+	}
+	return filepath.Join(filepath.Dir(s.metaPath), p)
+}
+
+func fileExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
 }
 
 func (s *Store) GetSnippet(name string) (string, bool) {
 	path, ok := s.meta.Snippets[name]
-	return path, ok
+	if ok {
+		resolved := s.resolvePath(path)
+		if fileExists(resolved) {
+			return resolved, true
+		}
+	}
+
+	// O(1) Fallback: Check the extension-based folder directly
+	ext := filepath.Ext(name)
+	if ext != "" {
+		langDir := strings.TrimPrefix(ext, ".")
+		snippetsDir := filepath.Join(filepath.Dir(s.metaPath), constants.SnippetsDirName)
+		fallbackPath := filepath.Join(snippetsDir, langDir, name)
+		if fileExists(fallbackPath) {
+			return fallbackPath, true
+		}
+	}
+
+	return "", false
 }
 
 func (s *Store) GetStack(name string) (string, bool) {
 	path, ok := s.meta.Stacks[name]
-	return path, ok
+	if ok {
+		resolved := s.resolvePath(path)
+		if fileExists(resolved) {
+			return resolved, true
+		}
+	}
+
+	// O(1) Fallback: Check the stacks folder directly
+	stacksDir := filepath.Join(filepath.Dir(s.metaPath), constants.StacksDirName)
+	fallbackPath := filepath.Join(stacksDir, name)
+	if fileExists(fallbackPath) {
+		return fallbackPath, true
+	}
+
+	return "", false
 }
 
 func (s *Store) RemoveSnippet(name string) error {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -111,6 +111,9 @@ func fileExists(path string) bool {
 func (s *Store) GetSnippet(name string) (string, bool) {
 	path, ok := s.meta.Snippets[name]
 	if ok {
+		if IsRemotePath(path) {
+			return path, true
+		}
 		resolved := s.resolvePath(path)
 		if fileExists(resolved) {
 			return resolved, true
@@ -134,6 +137,9 @@ func (s *Store) GetSnippet(name string) (string, bool) {
 func (s *Store) GetStack(name string) (string, bool) {
 	path, ok := s.meta.Stacks[name]
 	if ok {
+		if IsRemotePath(path) {
+			return path, true
+		}
 		resolved := s.resolvePath(path)
 		if fileExists(resolved) {
 			return resolved, true

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -32,7 +32,14 @@ func Uppercase(s string) string {
 
 // Title converts the string to Title Case (Every Word Capitalized).
 func Title(s string) string {
-	return strings.Title(strings.ToLower(s))
+	words := strings.Fields(strings.ToLower(s))
+	for i, word := range words {
+		if len(word) > 0 {
+			runes := []rune(word)
+			words[i] = string(unicode.ToUpper(runes[0])) + string(runes[1:])
+		}
+	}
+	return strings.Join(words, " ")
 }
 
 // CamelCase converts snake_case, kebab-case, or space separated words to camelCase.

--- a/internal/utils/strings.go
+++ b/internal/utils/strings.go
@@ -1,0 +1,103 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+var (
+	camelCaseRe = regexp.MustCompile(`(?:^|[-_])(\w)`)
+	snakeCaseRe = regexp.MustCompile(`([a-z0-9])([A-Z])`)
+)
+
+// Capitalize makes the first letter uppercase and the rest lowercase.
+func Capitalize(s string) string {
+	if len(s) == 0 {
+		return ""
+	}
+	runes := []rune(s)
+	return string(unicode.ToUpper(runes[0])) + strings.ToLower(string(runes[1:]))
+}
+
+// Lowercase converts the entire string to lowercase.
+func Lowercase(s string) string {
+	return strings.ToLower(s)
+}
+
+// Uppercase converts the entire string to uppercase.
+func Uppercase(s string) string {
+	return strings.ToUpper(s)
+}
+
+// Title converts the string to Title Case (Every Word Capitalized).
+func Title(s string) string {
+	return strings.Title(strings.ToLower(s))
+}
+
+// CamelCase converts snake_case, kebab-case, or space separated words to camelCase.
+func CamelCase(s string) string {
+	if s == "" {
+		return ""
+	}
+
+	// Convert all special characters and spaces to underscores first
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+
+	// Apply regex to convert _x to X
+	camel := camelCaseRe.ReplaceAllStringFunc(s, func(match string) string {
+		return strings.ToUpper(strings.TrimLeft(match, "-_"))
+	})
+
+	// Ensure the very first character is lowercase
+	if len(camel) > 0 {
+		runes := []rune(camel)
+		return string(unicode.ToLower(runes[0])) + string(runes[1:])
+	}
+	return camel
+}
+
+// PascalCase (UpperCamelCase) is like camelCase but the first letter is capitalized.
+func PascalCase(s string) string {
+	camel := CamelCase(s)
+	if len(camel) > 0 {
+		runes := []rune(camel)
+		return string(unicode.ToUpper(runes[0])) + string(runes[1:])
+	}
+	return camel
+}
+
+// SnakeCase converts CamelCase, kebab-case, or space separated words to snake_case.
+func SnakeCase(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+
+	// Insert underscores between lower/number and Upper case
+	s = snakeCaseRe.ReplaceAllString(s, "${1}_${2}")
+
+	// Convert spaces and hyphens to underscores
+	s = strings.ReplaceAll(s, "-", "_")
+	s = strings.ReplaceAll(s, " ", "_")
+
+	return strings.ToLower(s)
+}
+
+// KebabCase converts CamelCase, snake_case, or space separated words to kebab-case.
+func KebabCase(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+
+	// Insert hyphens between lower/number and Upper case
+	s = snakeCaseRe.ReplaceAllString(s, "${1}-${2}")
+
+	// Convert spaces and underscores to hyphens
+	s = strings.ReplaceAll(s, "_", "-")
+	s = strings.ReplaceAll(s, " ", "-")
+
+	return strings.ToLower(s)
+}

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -47,7 +47,9 @@ export default defineConfig({
         {
           label: 'Guides',
           items: [
-            { label: 'Boiler Syntax', slug: 'guides/syntax' },
+            { label: 'Project Structure', slug: 'guides/project-structure', badge: { text: 'Core', variant: 'note' } },
+            { label: 'Boiler Scripts (.bl)', slug: 'guides/bl-scripts', badge: { text: 'Advanced', variant: 'danger' } },
+            { label: 'Snippet Syntax', slug: 'guides/syntax' },
             {
               label: 'Remote Fetching',
               badge: { text: 'New', variant: 'tip' },

--- a/web/astro.config.mjs
+++ b/web/astro.config.mjs
@@ -50,6 +50,7 @@ export default defineConfig({
             { label: 'Project Structure', slug: 'guides/project-structure', badge: { text: 'Core', variant: 'note' } },
             { label: 'Boiler Scripts (.bl)', slug: 'guides/bl-scripts', badge: { text: 'Advanced', variant: 'danger' } },
             { label: 'Snippet Syntax', slug: 'guides/syntax' },
+            { label: 'Best Practices', slug: 'guides/best-practices' },
             {
               label: 'Remote Fetching',
               badge: { text: 'New', variant: 'tip' },

--- a/web/src/content/docs/commands/bl_add.md
+++ b/web/src/content/docs/commands/bl_add.md
@@ -34,8 +34,8 @@ Template Variables:
 - Variables are replaced and metadata comments are removed in the final file.
 
 Command Variables:
-- Use :name to resolve values from config vars (set via 'bl var').
-- Example: bl add express@1 -r --registry :team_reg
+- Use bl__varname to resolve values from config vars (set via 'bl var').
+- Example: bl add express@1 -r --registry bl__team_reg
 
 Stacks are also versioned and can be added by name or with explicit version.
 
@@ -123,8 +123,8 @@ bl add [resource] [destination] [flags]
   # Remote: one-time registry override
   bl add express@1 -r --registry https://github.com/myorg/boiler
 
-  # Remote: registry from config variable
-  bl add express@1 -r --registry :team_reg
+  # Remote: registry from config variable (set via: bl var team_reg=<url>)
+  bl add express@1 -r --registry bl__team_reg
 
   # One-shot fetch without saving to store
   bl add alice/my-stack -r --no-store

--- a/web/src/content/docs/commands/bl_alias.md
+++ b/web/src/content/docs/commands/bl_alias.md
@@ -10,30 +10,30 @@ Manage reusable command aliases
 Manage command aliases stored in boiler.conf.json.
 
 Usage patterns:
-- bl alias              List all aliases
-- bl alias name=cmd     Set or update an alias
-- bl alias name         Get one alias value
-- bl unalias name       Remove an alias (use 'unalias' command)
+
+  bl alias              List all aliases
+  bl alias name=cmd     Set or update an alias
+  bl alias name         Get one alias value
+  bl unalias name       Remove an alias (use 'unalias' command)
 
 Positional Arguments & Variables:
-- Aliases support dynamic positional arguments (bl__1, bl__2) and inline variables (bl__VAR_NAME).
+- Aliases support dynamic positional arguments (bl__1, bl__2, ...) and inline variables (bl__VAR_NAME).
 - When positional arguments are used, any trailing unconsumed arguments are automatically appended.
 
-Alias names are normalized internally:
-- Names are case-insensitive
-- Hyphens and underscores are preserved
+Alias names are case-insensitive. Hyphens and underscores are preserved.
 
-Examples:
-- # Simple aliases
-- bl alias ll=ls
-- bl alias s=search
+```bash
+# Simple aliases
+bl alias ll=ls
+bl alias s=search
 
-  # Alias with positional arguments (e.g. bl gi Node -> fetches Node.gitignore)
-  bl alias gi='use github/gitignore:bl__1.gitignore'
+# Alias with positional argument - bl gi Node fetches Node.gitignore
+bl alias gi='add github/gitignore:bl__1.gitignore . -m .gitignore -r'
 
-  # Alias with inline variables
-  bl var org=rishiyaduwanshi
-  bl alias templates='search --registry `https://github.com/bl__org/boiler'`
+# Alias referencing a stored var
+bl var org=rishiyaduwanshi
+bl alias templates='search --registry https://github.com/bl__org/boiler'
+```
 
 ```
 bl alias [name|name=command [args...]] [flags]

--- a/web/src/content/docs/commands/bl_new.md
+++ b/web/src/content/docs/commands/bl_new.md
@@ -1,0 +1,42 @@
+---
+title: bl new
+description: Command reference for bl new
+---
+
+Generate code using a Boiler script (.bl)
+
+### Synopsis
+
+Run a Boiler script (.bl) to generate, inject, or modify code in your project.
+
+Boiler automatically parses any flags (like --ts or --port=3000) and maps them to script variables.
+It looks for the script in the './bl/' folder of your current project.
+
+```
+bl new [script_name] [args...] [flags]
+```
+
+### Examples
+
+```
+  # Run the routes.bl script with positional arguments
+  bl new routes user auth
+
+  # Run with flags
+  bl new routes --ts --port=3000
+```
+
+### Options
+
+```
+  -h, --help   help for new
+```
+
+### Options inherited from parent commands
+
+```
+      --global    Force global scope for this command
+      --local     Force local scope for this command
+  -V, --verbose   Enable verbose debug output
+```
+

--- a/web/src/content/docs/guides/best-practices.mdx
+++ b/web/src/content/docs/guides/best-practices.mdx
@@ -1,0 +1,165 @@
+---
+title: Best Practices
+description: Tips, conventions, and recommended workflows for getting the most out of Boiler
+---
+
+## Snippet Conventions
+
+### Always Add Metadata Before Storing
+Run `bl init -n` to generate a properly formatted snippet file with metadata headers filled in. This keeps your store organized and readable.
+
+```bash
+bl init -n
+# Prompts: filename, author, description, version
+```
+
+### Use Descriptive, Specific Names
+
+```bash
+# ❌ Too generic
+bl store helper.js
+
+# ✅ Specific and searchable
+bl store jwtTokenHelper.js
+bl store mongoConnectionRetry.js
+```
+
+### Use `bl__` Variables for Configurable Values
+
+Instead of hardcoding values, use template variables so the snippet adapts when added:
+
+```javascript
+// __var bl__PORT = 3000
+// __var bl__DB_URL = mongodb://localhost:27017/mydb
+
+const app = express();
+app.listen(bl__PORT);
+mongoose.connect('bl__DB_URL');
+```
+
+---
+
+## Versioning
+
+### Version Strategically
+
+- Increment version (update `__version` in the file) only for **breaking changes**
+- Keep old versions around - legacy projects may depend on them
+- Use `bl add name@1` or `bl add name@2` to be explicit
+
+```bash
+bl add emailService@1    # Old projects - stays compatible
+bl add emailService@2    # New projects - gets the new API
+```
+
+### Search Before Creating
+
+```bash
+bl search jwt
+bl search validation
+# Check if a similar snippet already exists before adding another
+```
+
+---
+
+## Stacks (Project Templates)
+
+### Use Proper Ignore Patterns
+
+Before storing a directory as a stack, edit `boiler.stack.json` to exclude generated and secret files:
+
+```json
+{
+  "name": "express-api",
+  "ignore": [
+    "node_modules",
+    ".env",
+    "dist",
+    ".git",
+    "*.log"
+  ]
+}
+```
+
+### Use `--spread` for Root-Level Templates
+
+When you want the stack contents to land directly in the current directory (not inside a subdirectory):
+
+```bash
+bl add express-starter --spread
+# Contents land in ./ instead of ./express-starter/
+```
+
+---
+
+## Aliases & Variables
+
+### Build Short Commands for Repetitive Tasks
+
+```bash
+# Set a reusable alias
+bl alias gi = add github/gitignore:bl__1.gitignore . -m .gitignore -r
+
+# Now use it everywhere
+bl gi Node
+bl gi Python
+bl gi Go
+```
+
+### Use Vars as Registry Shortcuts
+
+Store a registry URL once, reference it anywhere with `bl__varname`:
+
+```bash
+# Save the registry URL as a var
+bl var team_reg = https://github.com/mycompany/boiler-snippets
+
+# Reference it with bl__varname prefix
+bl add errorHandler -r --registry bl__team_reg
+bl add rateLimiter -r --registry bl__team_reg
+```
+
+> `bl var` stores key-value pairs. Use `bl__varname` anywhere in a command to have Boiler substitute the stored value at runtime.
+
+---
+
+## Local Scoped Projects
+
+### Use `boiler.local.json` for Project-Specific Templates
+
+For components, controllers, or routes that are specific to one project and shouldn't pollute your global `~/.boiler` store:
+
+```bash
+bl init -c          # Creates boiler.local.json with scope: local
+```
+
+Then keep your project templates inside `bl/snippets/` and your automation scripts in `bl/commands/`.
+
+### Check Info Before Adding
+
+```bash
+bl info errorHandler@2
+# Shows: author, description, version, variables
+```
+
+This helps avoid surprises - especially with template variables.
+
+---
+
+## Cleaning Up
+
+```bash
+bl clean -n              # Remove all snippets
+bl clean -k              # Remove all stacks
+bl clean --snippets      # Same as -n
+bl clean --stacks        # Same as -k
+bl search <name>         # Find before removing a specific one
+```
+
+---
+
+## Next Steps
+
+- [Use Cases](/guides/usecases/) - Real-world workflows
+- [Boiler Scripts (.bl)](/guides/bl-scripts/) - Full automation pipelines
+- [Remote Fetching](/guides/remote-fetching/) - Fetch from GitHub/GitLab/anywhere

--- a/web/src/content/docs/guides/bl-scripts.mdx
+++ b/web/src/content/docs/guides/bl-scripts.mdx
@@ -16,13 +16,13 @@ A `.bl` file consists of metadata variables, Boiler CLI commands, and code injec
 ```bash
 # Define metadata and variables using __ (Double Underscore)
 __desc = "Generates a new API Route"
-__var bl__route_name = lowercase(bl__1)    # bl__1 is the first argument passed to the command
+__var bl__route_name = bl__1.lowercase()    # bl__1 is the first argument passed to the command
 
 # Run standard Boiler commands
 use github.com/my-org/repo:route.ts ./src/routes/bl__route_name.ts
 
-# Inject code into existing files
-inject ./src/routes.ts --detector api_routes --mode append --content `
+# Inject code into existing files using CLI flags (-d for detect, -a for append, -p for prepend, -c for content)
+inject ./src/routes.ts -d api_routes -a -c `
 import { bl__route_name } from './routes/bl__route_name';
 app.use('/api/bl__route_name', bl__route_name);
 `
@@ -32,12 +32,22 @@ app.use('/api/bl__route_name', bl__route_name);
 
 ## 1. Variables and Metadata
 All metadata and variables must start with a double underscore `__`. 
-Variables can access CLI arguments using `bl__1`, `bl__2`, etc. You can also use built-in transformers like `lowercase()`, `capitalize()`, etc.
+Variables can access CLI arguments using `bl__1`, `bl__2`, etc. You can also use built-in transformers like `.lowercase()`, `.capitalize()`, etc. using dot-notation.
 
 ```bash
 __desc = "This text shows up in the CLI help menu"
-__var bl__component = capitalize(bl__1)
+__var bl__component = bl__1.capitalize()
 ```
+
+**Supported Modifiers:**
+- `.lowercase()` / `.lower()`
+- `.uppercase()` / `.upper()`
+- `.capitalize()`
+- `.titleCase()`
+- `.camelCase()`
+- `.pascalCase()`
+- `.snake_case()`
+- `.kebab_case()` / `.kebabCase()`
 
 ---
 
@@ -48,12 +58,18 @@ When you need to inject complex or multi-line code blocks, always use backticks 
 > **No Escaping Needed:** Code inside backticks is protected. You can freely use double quotes (`"`), single quotes (`'`), or any special characters without needing to escape them.
 
 ```bash
-inject ./src/index.js --detector imports --mode append --content `
+inject ./src/index.js -d imports -a -c `
 const express = require('express');
 const app = express();
 console.log("Server initialized");
 `
 ```
+
+**Injection Flags:**
+- `-d` or `--detect`: The name of the detector (e.g. `imports` targets `// bl__DETECTOR_START_imports`).
+- `-a` or `--append`: Inserts the content right *above* the `END` marker. Ideal for adding items to the end of a list.
+- `-p` or `--prepend`: Inserts the content right *below* the `START` marker. Ideal for adding imports at the top of a block.
+- `-c` or `--content`: Followed by backticks containing the multiline code.
 
 ---
 

--- a/web/src/content/docs/guides/bl-scripts.mdx
+++ b/web/src/content/docs/guides/bl-scripts.mdx
@@ -5,6 +5,9 @@ description: Learn how to write powerful, AST-less automation scripts using .bl 
 
 Boiler allows you to create powerful automation workflows using `.bl` script files. These files live in your project's `bl/commands/` directory and can be executed using the `bl new` command.
 
+> [!TIP]
+> **Dynamic Project Root:** You can run `bl new` from *any* subdirectory inside your project. Boiler automatically discovers your `boiler.local.json` file and executes the script relative to your project root. Path references like `./src/` will always point to the correct location!
+
 `.bl` scripts are designed to be extremely fast and lightweight. They use a **Pure Command-Driven** syntax that is executed line-by-line, without the overhead of a complex Abstract Syntax Tree (AST).
 
 ---
@@ -18,8 +21,8 @@ A `.bl` file consists of metadata variables, Boiler CLI commands, and code injec
 __desc = "Generates a new API Route"
 __var bl__route_name = bl__1.lowercase()    # bl__1 is the first argument passed to the command
 
-# Run standard Boiler commands
-use github.com/my-org/repo:route.ts ./src/routes/bl__route_name.ts
+# Run standard Boiler commands (like adding a snippet)
+add route.ts ./src/routes/bl__route_name.ts --local
 
 # Inject code into existing files using CLI flags (-d for detect, -a for append, -p for prepend, -c for content)
 inject ./src/routes.ts -d api_routes -a -c `
@@ -48,6 +51,9 @@ __var bl__component = bl__1.capitalize()
 - `.pascalCase()`
 - `.snake_case()`
 - `.kebab_case()` / `.kebabCase()`
+
+> [!IMPORTANT]
+> **Silent Scaffolding Pipeline:** When your script defines variables, they are automatically injected into the Boiler engine's runtime environment (`BOILER_VAR_`). If a subsequent command (like `bl add`) needs those variables to scaffold a file, **it will automatically consume the environment variables and skip the interactive prompts!**.
 
 ---
 

--- a/web/src/content/docs/guides/bl-scripts.mdx
+++ b/web/src/content/docs/guides/bl-scripts.mdx
@@ -1,0 +1,115 @@
+---
+title: Boiler Scripts (.bl)
+description: Learn how to write powerful, AST-less automation scripts using .bl files.
+---
+
+Boiler allows you to create powerful automation workflows using `.bl` script files. These files live in your project's `bl/commands/` directory and can be executed using the `bl new` command.
+
+`.bl` scripts are designed to be extremely fast and lightweight. They use a **Pure Command-Driven** syntax that is executed line-by-line, without the overhead of a complex Abstract Syntax Tree (AST).
+
+---
+
+## Basic Structure
+
+A `.bl` file consists of metadata variables, Boiler CLI commands, and code injection statements.
+
+```bash
+# Define metadata and variables using __ (Double Underscore)
+__desc = "Generates a new API Route"
+__var bl__route_name = lowercase(bl__1)    # bl__1 is the first argument passed to the command
+
+# Run standard Boiler commands
+use github.com/my-org/repo:route.ts ./src/routes/bl__route_name.ts
+
+# Inject code into existing files
+inject ./src/routes.ts --detector api_routes --mode append --content `
+import { bl__route_name } from './routes/bl__route_name';
+app.use('/api/bl__route_name', bl__route_name);
+`
+```
+
+---
+
+## 1. Variables and Metadata
+All metadata and variables must start with a double underscore `__`. 
+Variables can access CLI arguments using `bl__1`, `bl__2`, etc. You can also use built-in transformers like `lowercase()`, `capitalize()`, etc.
+
+```bash
+__desc = "This text shows up in the CLI help menu"
+__var bl__component = capitalize(bl__1)
+```
+
+---
+
+## 2. Multi-line Injection (Backticks)
+When you need to inject complex or multi-line code blocks, always use backticks (`` ` ``).
+
+> [!TIP]
+> **No Escaping Needed:** Code inside backticks is protected. You can freely use double quotes (`"`), single quotes (`'`), or any special characters without needing to escape them.
+
+```bash
+inject ./src/index.js --detector imports --mode append --content `
+const express = require('express');
+const app = express();
+console.log("Server initialized");
+`
+```
+
+---
+
+## 3. Control Flow (If / Else)
+Boiler scripts support conditional execution using C-style preprocessor directives (`#if`, `#else`, `#endif`). This keeps the engine blazing fast while giving you full logic control.
+
+### Basic Conditionals
+```bash
+__var bl__is_ts = has_flag("--ts")
+
+#if bl__is_ts
+  use github.com/org/repo:types.ts ./src/types.ts
+#else
+  use github.com/org/repo:types.js ./src/types.js
+#endif
+```
+
+### Logical Operators
+You can combine multiple conditions using `&&` (AND) and `||` (OR). You can also use `!` (NOT), `==` (Equals), and `!=` (Not Equals).
+
+> [!WARNING]
+> **No Brackets Allowed:** To keep the parser AST-less and fast, parentheses `()` for grouping logic are **not supported**. Conditions are evaluated linearly.
+
+```bash
+# Run if both are true
+#if bl__db_type == "mongodb" && bl__is_ts
+  use github.com/repo:mongo.ts ./src/db.ts
+#endif
+
+# Run if either is true
+#if bl__db_type == "postgres" || bl__db_type == "mysql"
+  run npm install pg sequelize
+#endif
+
+# Run if NOT true
+#if !bl__is_ts
+  run echo "Using JavaScript"
+#endif
+```
+
+---
+
+## 4. Handling Dependencies
+Boiler scripts are evaluated strictly from top to bottom. If your script depends on external NPM packages or other Boiler scripts, simply `run` them at the top of your file.
+
+```bash
+__desc = "Scaffolds an Auth module"
+
+# 1. Install NPM dependencies first
+run npm install jsonwebtoken bcryptjs
+
+# 2. Run another Boiler command (Script Dependency)
+run bl new database
+
+# 3. Proceed with file scaffolding
+use github.com/org/repo:auth.ts ./src/auth.ts
+```
+
+By keeping dependencies procedural, the script's behavior remains 100% predictable.

--- a/web/src/content/docs/guides/introduction.md
+++ b/web/src/content/docs/guides/introduction.md
@@ -1,38 +1,102 @@
 ---
 title: Introduction
-description: Learn what Boiler is and how it can help you manage code snippets and project stacks
+description: Boiler is a code automation engine - fetch, scaffold, and reuse code across every project
 ---
 
-Boiler is a powerful CLI tool designed to help developers manage and reuse code snippets and project stacks efficiently.
+Boiler is a CLI tool that turns repetitive coding tasks into single commands. Fetch code from anywhere, scaffold full features, and reuse your best work across every project.
 
-## What is Boiler?
+## What Can You Do With Boiler?
 
-Boiler allows you to:
+### Fetch From Anywhere - Without `git clone`
 
-- **Store** code snippets and entire project stacks
-- **Version** your resources automatically
-- **Reuse** code across multiple projects effortlessly
-- **Share** snippets and stacks with your team via a shared registry (GitHub, GitLab, Bitbucket, or your own server)
+Pull individual files, specific folders, or entire repos from GitHub, GitLab, Bitbucket, or any direct URL:
 
-## Key Features
+```bash
+bl use alice/snippets:js/errorHandler.js ./src/utils
+bl use vercel/next.js:examples/blog ./my-blog
+bl use https://gitlab.com/myorg/templates:Dockerfile .
+```
 
-### Auto-Versioning
-Never worry about overwriting your work. Boiler automatically manages versions of all your resources.
+### Instant Gitignores for Any Stack
 
-### Lightning Fast
-Built with Go, Boiler is optimized for speed. Store and retrieve your code in milliseconds.
+The built-in `gi` alias connects to 225+ popular templates and 300+ community templates:
 
-### Smart Detection
-Boiler automatically detects file types and folder structures, so you don't need to configure anything manually.
+```bash
+bl gi Node
+bl gi Python
+bl gi Go
+bl gi Global/macOS
+```
 
-### Language Agnostic
-Works with any programming language - JavaScript, Python, Go, Java, C++, and more.
+### Store & Reuse Your Own Code
 
-## Use Cases
+```bash
+bl store utils/debounce.js     # Store once
+bl add debounce ./src/utils    # Reuse anywhere
+```
 
-- **Code Snippets**: Store frequently used code patterns like error handlers, utilities, or configurations
-- **Project Templates**: Save complete project structures as stacks for quick initialization
-- **Team Collaboration**: Share snippets and stacks across your team
-- **Personal Library**: Build your own library of reusable code
+Template variables let you customize snippets on the fly - `bl__VAR_NAME` placeholders are prompted interactively when you add them.
 
+### Automate Full Feature Scaffolding
 
+Write `.bl` scripts that create multiple files, inject code into existing ones, and run commands - triggered with a single `bl new` call:
+
+```bash
+bl new feat user
+# Creates: src/routes/user.route.js, src/controllers/user.controller.js
+# Injects: imports and app.use() into src/api.js automatically
+```
+
+---
+
+## Core Concepts
+
+<table>
+  <thead>
+    <tr>
+      <th>Concept</th>
+      <th>What it is</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Snippet</strong></td>
+      <td>A single file stored in your Boiler store</td>
+    </tr>
+    <tr>
+      <td><strong>Stack</strong></td>
+      <td>An entire directory/project template</td>
+    </tr>
+    <tr>
+      <td><strong>.bl Script</strong></td>
+      <td>An automation script run with <code>bl new</code></td>
+    </tr>
+    <tr>
+      <td><strong>Global Store</strong></td>
+      <td><code>~/.boiler/</code> - shared across all your projects</td>
+    </tr>
+    <tr>
+      <td><strong>Local Store</strong></td>
+      <td><code>bl/</code> inside your project - project-specific templates</td>
+    </tr>
+    <tr>
+      <td><strong>Registry</strong></td>
+      <td>A GitHub/GitLab repo used as a shared snippet library for teams</td>
+    </tr>
+  </tbody>
+</table>
+
+---
+
+## Language & Platform Agnostic
+
+Boiler works with **any file type** - JavaScript, TypeScript, Python, Go, Rust, Java, C++, Dockerfiles, shell scripts, config files, and more. It runs on **Windows, macOS, and Linux**.
+
+---
+
+## Next Steps
+
+- [Installation](/guides/installation/) - Get Boiler running in 30 seconds
+- [Quick Start](/guides/quickstart/) - Your first snippet in 5 minutes
+- [Use Cases](/guides/usecases/) - Real-world workflows and examples
+- [Boiler Scripts (.bl)](/guides/bl-scripts/) - Write full automation pipelines

--- a/web/src/content/docs/guides/project-structure.mdx
+++ b/web/src/content/docs/guides/project-structure.mdx
@@ -1,0 +1,78 @@
+---
+title: Project Structure & Architecture
+description: Understand how Boiler manages configurations, templates, and generated code in your projects.
+---
+
+Boiler is designed to be extremely flexible while keeping your project root clean. It distinguishes between **Global** settings (for your machine) and **Local** settings (specific to a project), and it strictly separates **Boiler internal assets** from **your generated code**.
+
+## Global vs Local Configuration
+
+Boiler uses a cascading configuration system. It first loads your Global config, then overrides it with your Local config if you are inside a project that has one.
+
+### Global Configuration (`~/.boiler/boiler.conf.json`)
+This is your machine-wide configuration. It contains your default author name, preferred text editor, and the default registry.
+- **Location:** `~/.boiler/boiler.conf.json`
+- **Global Store:** By default, all globally downloaded snippets and stacks are saved to `~/.boiler/store/`.
+
+### Local Configuration (`boiler.local.json`)
+If you want to define custom aliases, variables, or override the store path for a specific project, you can initialize a local configuration.
+- **Command:** Run `bl init -c` to generate this file.
+- **Location:** Project root (`./boiler.local.json`).
+
+> **Note:** A local config file is optional. If not found, Boiler will fall back to your Global config.
+
+---
+
+## Directory Structure
+
+To prevent collisions between your project's generated code and Boiler's internal custom templates, Boiler uses two distinct directories in your project:
+
+### 1. The `bl/` Directory (Boiler's Internal Assets)
+This is where you store your project-specific reusable components, snippets, and custom CLI commands. Because this folder is visible (no dot prefix), you can easily edit and manage your templates in your IDE.
+
+```text
+my-project/
+└── bl/
+    ├── commands/      # Custom .bl scripts (e.g., generate_route.bl)
+    ├── snippets/      # Local snippets
+    └── stacks/        # Local project scaffolds
+```
+
+When you run a command like `bl new`, Boiler automatically looks inside the `bl/commands/` folder to find the script.
+
+### 2. The `boiler/` Directory (Generated Code)
+By default, when you download or add a new snippet or stack to your project, Boiler places the generated code inside the `boiler/` folder in your project root. 
+
+```text
+my-project/
+└── boiler/
+    ├── user_auth_component/
+    └── utils.js
+```
+
+### Why the Separation?
+Imagine you scaffold a new component named `commands`. If Boiler's internal files and your generated code shared the same folder, your new component would overwrite or mix with Boiler's `.bl` scripts! 
+By keeping templates in `bl/` and generated code in `boiler/`, we guarantee zero collisions while keeping everything perfectly organized.
+
+---
+
+## Example Project Layout
+
+Here is what a fully configured project utilizing Boiler looks like:
+
+```text
+my-project/
+├── boiler.local.json      # Boiler config (aliases, vars)
+├── package.json
+│
+├── bl/                    # [Boiler Internals]
+│   ├── commands/
+│   │   └── api.bl     # Your custom generator script
+│   └── snippets/
+│       └── my-header.tsx  # Your custom reusable snippet
+│
+├── boiler/                # [Generated Output]
+│   └── (Generated code lands here by default)
+│
+└── src/                   # Your actual application code
+```

--- a/web/src/content/docs/guides/quickstart.md
+++ b/web/src/content/docs/guides/quickstart.md
@@ -1,129 +1,114 @@
 ---
 title: Quick Start
-description: Get started with Boiler in 5 minutes
+description: Get Boiler running and do something useful in 5 minutes
 ---
 
-Learn the basics of Boiler in just a few minutes.
+## Your First Snippet
 
-## 1. Store Your First Snippet
+Create a file with template variables and store it:
 
-Create and store a simple error handler:
+```javascript
+// errorHandler.js
+// __author Your Name
+// __desc Custom error handler
+// __var bl__LOG_LEVEL = error
+
+function handleError(err) {
+  console[bl__LOG_LEVEL](err.message);
+}
+
+module.exports = handleError;
+```
 
 ```bash
-# Create a file
-echo "function handleError(err) { console.error(err); }" > errorHandler.js
-
-# Store it
 bl store errorHandler.js
+# ✓ Snippet stored: errorHandler@1.js
 ```
 
-Output: `✓ Snippet stored: errorHandler@1.js`
-
-## 2. List Your Snippets
-
-View all your stored snippets:
+Use it in any project:
 
 ```bash
-bl ls --snippets
+cd ~/another-project
+bl add errorHandler ./src/utils
+#   bl__LOG_LEVEL [error]: warn
+# ✓ Snippet added: errorHandler@1.js → ./src/utils/errorHandler.js
 ```
 
-Output:
-```
-📄 Snippets:
-  • errorHandler@1.js
+The metadata comments are stripped, `bl__LOG_LEVEL` is replaced with `warn`. Clean code, ready to use.
 
-📦 Stacks:
-  No stacks found
-```
+---
 
-## 3. Use the Snippet in Another Project
+## Instant `.gitignore`
 
-Navigate to a different directory and add the snippet:
+The `gi` alias ships by default - wired to 500+ gitignore templates:
 
 ```bash
-cd ../my-other-project
-bl add errorHandler
+bl gi Node           # Node.js
+bl gi Python         # Python
+bl gi Go             # Go
+bl gi Global/macOS   # macOS global
 ```
 
-Output: `✓ Snippet added: errorHandler@1.js → boiler/errorHandler.js`
+---
 
-The snippet is copied to the default `boiler/` directory.
-
-## 4. Store a Project Stack
-
-Store an entire project directory as a stack:
+## Fetch From GitHub Without `git clone`
 
 ```bash
-# First, initialize stack config (required before storing a directory)
-cd my-express-app
-bl init
-# Prompts for stack name, description, author, and files to ignore
+# Single file from any public repo
+bl use alice/snippets:utils/debounce.js ./src/utils
 
-# Then store it
-bl store
+# Entire subfolder as a template
+bl use vercel/next.js:examples/with-tailwindcss ./my-project
+
+# Save to local store for reuse later
+bl add alice/snippets:utils/debounce.js -r
 ```
 
-Output: `✓ Stored stack 'express-starter@1' at /path/to/store/stacks/express-starter@1`
+---
 
-## 5. Initialize a New Project from Stack
-
-Start a new project using your stack:
+## Store a Project Template (Stack)
 
 ```bash
-mkdir new-project
-cd new-project
-bl add express-starter
+cd my-express-template
+bl init          # Creates boiler.stack.json (name, ignore patterns)
+bl store         # Stores the entire directory as a stack
 ```
 
-Output: `✓ Stack added: express-starter@1 → boiler/express-starter`
+Start new projects from it:
 
-Your stack is copied to `./boiler/express-starter` by default.
-
-## Common Commands
-
-### Store Resources
 ```bash
-bl store <file>              # Store a snippet
-bl store <folder> --stack    # Store a stack
+mkdir new-api && cd new-api
+bl add express-template --spread    # Spreads contents into ./
+npm install
 ```
 
-### Add Resources
+---
+
+## Essential Commands
+
 ```bash
-bl add <name>                # Add snippet/stack into ./boiler
-bl add <name> <path>         # Add to a specific relative/absolute path
-bl add <name> --spread       # Spread stack contents into destination
-bl add <name@version.ext>    # Add specific version
+bl store <file>              # Store a file as snippet
+bl store <folder>            # Store a folder as stack (requires bl init first)
+bl add <name> [path]         # Add snippet or stack to a path (default: ./boiler)
 bl add <name> -r             # Fetch from remote registry and save locally
-bl use <url-or-repo>         # One-shot fetch from anywhere (no local store)
+bl use <url-or-repo> [path]  # One-shot fetch (no local caching)
+bl gi <language>             # Instant gitignore for any language
+bl ls                        # List all stored resources
+bl search <query>            # Search by name (add -r to search remote)
+bl info <name>               # Show details about a resource
+bl new <script>              # Run a .bl automation script
+bl alias [k=v]               # Create a command shortcut
+bl var [k=v]                 # Set a reusable variable
+bl conf                      # View or edit your configuration
+bl clean                     # Remove resources from your store
+bl self update               # Update Boiler to the latest version
 ```
 
-### List Resources
-```bash
-bl ls                        # List all
-bl ls --snippets             # List only snippets
-bl ls --stacks               # List only stacks
-```
+---
 
-### Get Information
-```bash
-bl info <name>               # Show resource details
-bl path                      # Show store location
-```
+## Next Steps
 
-### Search and Clean
-```bash
-bl search <query>            # Search by name
-bl clean <name>              # Remove a resource
-```
-
-## What You've Learned
-
-- ✓ Store files as snippets with `bl store`
-- ✓ Store directories as stacks with `bl store --stack`
-- ✓ List resources with `bl ls`
-- ✓ Add resources with `bl add` (auto-detects single versions)
-- ✓ Get info with `bl info`
-
-You're now ready to use Boiler in your daily workflow!
-
-
+- [Use Cases](/guides/usecases/) - Real-world workflows and examples
+- [Project Structure](/guides/project-structure/) - How `bl/` and `boiler/` work
+- [Boiler Scripts (.bl)](/guides/bl-scripts/) - Write full automation pipelines
+- [Remote Fetching](/guides/remote-fetching/) - Fetch from GitHub, GitLab, anywhere

--- a/web/src/content/docs/guides/remote-fetching.mdx
+++ b/web/src/content/docs/guides/remote-fetching.mdx
@@ -11,10 +11,27 @@ Boiler can fetch resources from **anywhere** - GitHub, GitLab, Bitbucket, your o
 
 ## Two Commands for Remote Fetching
 
-| Command | Saves to local store? | Use case |
-|---|---|---|
-| `bl add ... -r` | ✅ Yes - reusable later with `bl add <name>` | Team/personal registry, frequently reused resources |
-| `bl use ...` | ❌ No - one-shot fetch | Grab something once, no clutter |
+<table>
+  <thead>
+    <tr>
+      <th>Command</th>
+      <th>Saves to local store?</th>
+      <th>Use case</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>bl add ... -r</code></td>
+      <td>✅ Yes - reusable later with <code>bl add &lt;name&gt;</code></td>
+      <td>Team/personal registry, frequently reused resources</td>
+    </tr>
+    <tr>
+      <td><code>bl use ...</code></td>
+      <td>❌ No - one-shot fetch</td>
+      <td>Grab something once, no clutter</td>
+    </tr>
+  </tbody>
+</table>
 
 ---
 
@@ -22,13 +39,42 @@ Boiler can fetch resources from **anywhere** - GitHub, GitLab, Bitbucket, your o
 
 Boiler auto-detects the right provider from the URL:
 
-| Platform | Format | Archive |
-|---|---|---|
-| **GitHub** | `owner/repo` or `https://github.com/owner/repo` | tar.gz |
-| **GitLab** | `https://gitlab.com/owner/repo` | tar.gz |
-| **Bitbucket** | `https://bitbucket.org/owner/repo` | zip |
-| **Custom registry** | `https://yoursite.com/boiler-store` | zip |
-| **Direct archive** | `https://anysite.com/stack.zip` or `.tar.gz` | auto-detected |
+<table>
+  <thead>
+    <tr>
+      <th>Platform</th>
+      <th>Format</th>
+      <th>Archive</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>GitHub</strong></td>
+      <td><code>owner/repo</code> or <code>https://github.com/owner/repo</code></td>
+      <td>tar.gz</td>
+    </tr>
+    <tr>
+      <td><strong>GitLab</strong></td>
+      <td><code>https://gitlab.com/owner/repo</code></td>
+      <td>tar.gz</td>
+    </tr>
+    <tr>
+      <td><strong>Bitbucket</strong></td>
+      <td><code>https://bitbucket.org/owner/repo</code></td>
+      <td>zip</td>
+    </tr>
+    <tr>
+      <td><strong>Custom registry</strong></td>
+      <td><code>https://yoursite.com/boiler-store</code></td>
+      <td>zip</td>
+    </tr>
+    <tr>
+      <td><strong>Direct archive</strong></td>
+      <td><code>https://anysite.com/stack.zip</code> or <code>.tar.gz</code></td>
+      <td>auto-detected</td>
+    </tr>
+  </tbody>
+</table>
 
 ---
 
@@ -36,13 +82,42 @@ Boiler auto-detects the right provider from the URL:
 
 The colon (`:`) separates the **source** from the **path inside it**.
 
-| What You Want | Format | Example |
-|---|---|---|
-| Whole GitHub/GitLab/Bitbucket repo | `owner/repo` or full URL | `alice/my-stack` |
-| File inside a GitHub repo | `owner/repo:path/to/file.js` | `alice/snippets:js/logger.js` |
-| Custom domain file | `domain.com:path/file` | `mysite.com:snippets/util.js` |
-| Direct file URL | `https://full-url` | `https://mysite.com/file.js` |
-| Direct archive URL | `https://full-url.zip` | `https://mysite.com/stack.zip` |
+<table>
+  <thead>
+    <tr>
+      <th>What You Want</th>
+      <th>Format</th>
+      <th>Example</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Whole GitHub/GitLab/Bitbucket repo</td>
+      <td><code>owner/repo</code> or full URL</td>
+      <td><code>alice/my-stack</code></td>
+    </tr>
+    <tr>
+      <td>File inside a GitHub repo</td>
+      <td><code>owner/repo:path/to/file.js</code></td>
+      <td><code>alice/snippets:js/logger.js</code></td>
+    </tr>
+    <tr>
+      <td>Custom domain file</td>
+      <td><code>domain.com:path/file</code></td>
+      <td><code>mysite.com:snippets/util.js</code></td>
+    </tr>
+    <tr>
+      <td>Direct file URL</td>
+      <td><code>https://full-url</code></td>
+      <td><code>https://mysite.com/file.js</code></td>
+    </tr>
+    <tr>
+      <td>Direct archive URL</td>
+      <td><code>https://full-url.zip</code></td>
+      <td><code>https://mysite.com/stack.zip</code></td>
+    </tr>
+  </tbody>
+</table>
 
 ---
 

--- a/web/src/content/docs/guides/syntax.md
+++ b/web/src/content/docs/guides/syntax.md
@@ -142,23 +142,6 @@ DATABASE_CONFIG = {
 }
 ```
 
-## Comment Styles by Language
-
-Boiler automatically uses the correct comment style based on file extension:
-
-| Language/File | Extension | Comment Style | Example |
-|--------------|-----------|---------------|---------|
-| JavaScript/TypeScript | `.js`, `.ts` | `//` | `// __author Name` |
-| Python | `.py` | `#` | `# __author Name` |
-| HTML/XML | `.html`, `.xml` | `<!--` | `<!-- __author Name -->` |
-| CSS | `.css` | `/*` | `/* __author Name */` |
-| SQL | `.sql` | `--` | `-- __author Name` |
-| Shell Script | `.sh`, `.bash` | `#` | `# __author Name` |
-| PowerShell | `.ps1` | `#` | `# __author Name` |
-| Ruby | `.rb` | `#` | `# __author Name` |
-| YAML | `.yml`, `.yaml` | `#` | `# __author Name` |
-| INI/Config | `.ini`, `.env` | `;` or `#` | `# __author Name` |
-
 ### Custom Comment Styles
 
 For unsupported file types, add them to your config:

--- a/web/src/content/docs/guides/usecases.md
+++ b/web/src/content/docs/guides/usecases.md
@@ -1,386 +1,234 @@
 ---
 title: Use Cases
-description: Real-world scenarios and practical examples of using Boiler
+description: Real-world scenarios showing what you can actually do with Boiler
 ---
 
-Boiler is designed to eliminate repetitive coding tasks by storing and reusing code across projects. Here are practical use cases to get the most out of it.
-
----
-
-## 1. Avoid Installing Entire Packages for Small Utilities
-
-**Have you ever thought:** Sometimes we add a package even for a small use case?
-
-**The Problem:**
-```bash
-# Just need one function from lodash?
-npm install lodash  # 1.4MB for one function!
-
-# Need a date formatter?
-npm install moment  # 289KB for basic formatting!
-```
-
-**Boiler Solution:**
-```javascript
-// debounce.js
-// __author Your Name
-// __desc Debounce utility without lodash
-
-function debounce(func, wait) {
-  let timeout;
-  return function executedFunction(...args) {
-    const later = () => {
-      clearTimeout(timeout);
-      func(...args);
-    };
-    clearTimeout(timeout);
-    timeout = setTimeout(later, wait);
-  };
-}
-
-module.exports = debounce;
-```
-
-```bash
-# Store once
-bl store debounce.js
-
-# Reuse everywhere - no package needed!
-bl add debounce
-```
-
-**Benefits:**
-- **Zero dependencies** - No node_modules bloat
-- **Lightweight** - Only the code you need
-- **Custom tailored** - Modify to your exact needs
-- **Bundle size** - Smaller production builds
-
-**Perfect for:** Small utilities like debounce, throttle, formatters, validators, parsers, etc.
+Boiler is a **code automation engine** - not just a snippet manager. Here's what developers actually do with it.
 
 ---
 
-## 2. Store & Reuse API Middleware
+## 1. Instant `.gitignore` for Any Language or Framework
 
-**Scenario:** You use the same authentication middleware in every Express project.
+Boiler ships with a built-in `gi` alias wired to the official [github/gitignore](https://github.com/github/gitignore) repository - **225+ popular templates** and **300+ community templates** (version-specific, specialized tools, editors, OS).
 
 ```bash
-# Store it once
-cd my-express-project
-bl store middleware/auth.js
+# Node.js
+bl gi Node
 
-# Use in any new project
-cd new-project
-bl add auth
+# Python
+bl gi Python
+
+# Go
+bl gi Go
+
+# macOS (global)
+bl gi Global/macOS
+
+# JetBrains IDEs (community)
+bl gi community/JetBrains+all
 ```
 
-**Result:** Never write `verifyToken()` or `requireAuth()` again.
+**That's it.** No copying from gitignore.io, no searching GitHub manually. The `.gitignore` appears instantly in your current directory.
+
+> The `gi` alias works by combining **Alias + Variable** power under the hood:
+> ```
+> add github/gitignore:bl__1.gitignore . -m .gitignore -r
+> ```
+> `bl__1` is replaced with your argument - that's the entire magic.
 
 ---
 
-## 3. Database Connection Configs
+## 2. Pull Any File or Repo Without `git clone`
 
-**Scenario:** MongoDB/PostgreSQL connection setup is identical across microservices.
+Boiler can fetch **individual files**, **specific folders**, or **entire repositories** from GitHub, GitLab, or Bitbucket - without ever running `git clone` or downloading a ZIP manually.
 
 ```bash
-# Store your database config
-bl store config/db.js
+# Grab a single file from a GitHub repo
+bl use alice/snippets:js/errorHandler.js ./src/utils
 
-# Add to any service instantly
-cd user-service
-bl add db
+# Grab a specific subfolder as a template
+bl use vercel/next.js:examples/blog ./new-blog
+
+# Grab an entire repo
+bl use rishiyaduwanshi/express-starter ./my-api
+
+# From GitLab
+bl use https://gitlab.com/myorg/templates:docker/node.Dockerfile .
+
+# From any direct URL
+bl use https://raw.githubusercontent.com/user/repo/main/Dockerfile .
 ```
 
-**Perfect for:** Microservice architectures where consistency matters.
+The resource lands exactly where you point it, fully processed. No extra cleanup needed.
 
 ---
 
-## 4. Error Handlers & Logging Utilities
+## 3. Full Feature Scaffolding in One Command
 
-**Scenario:** You have a custom error handler and logger you always use.
+Using `.bl` scripts with the `bl new` command, you can scaffold an entire feature - route, controller, model - and automatically wire them into your existing files, all in a single command.
+
+**Example:** `bl new feat user`
+
+This runs a script (`bl/commands/feat.bl`) that:
+1. Creates `src/routes/user.route.js` (from a template)
+2. Creates `src/controllers/user.controller.js` (from a template)
+3. **Injects** `import userRouter from './routes/user.route.js'` into `src/api.js`
+4. **Injects** `app.use('/user', userRouter)` into `src/api.js`
 
 ```bash
-# Store utilities
-bl store utils/errorHandler.js
-bl store utils/appLogger.js
+# feat.bl script
+__desc = "Scaffold a new API feature"
+__var bl__feature = bl__1.lowercase()
+__var bl__Feature = bl__1.capitalize()
 
-# Add both to new project
-bl add errorHandler
-bl add appLogger
+add route.js ./src/routes/bl__feature.route.js --local
+add controller.js ./src/controllers/bl__feature.controller.js --local
+
+inject ./src/api.js -d imports -a -c `
+import bl__featureRouter from './routes/bl__feature.route.js';
+`
+
+inject ./src/api.js -d routes -a -c `
+app.use('/bl__feature', bl__featureRouter);
+`
 ```
 
-**Why it matters:** Consistent error handling across all projects.
+**Result:** Your feature is fully scaffolded and connected - zero manual wiring.
 
 ---
 
-## 5. Project Boilerplates (Stacks)
+## 4. Team-Wide Standards via Shared Registry
 
-**Scenario:** You repeatedly scaffold Express APIs with the same structure.
-
-```bash
-# Create your perfect Express template once
-cd my-express-template
-bl init  # Creates boiler.stack.json
-
-# Customize boiler.stack.json to exclude node_modules, .env
-# Then store the entire structure
-bl store
-
-# Start new projects in seconds
-mkdir new-api && cd new-api
-bl add express-api@1
-npm install
-```
-
-**Use for:**
-- Express/Fastify APIs
-- Next.js starters
-- Django REST templates
-- Microservice scaffolds
-
----
-
-## 6. Team Snippet Library
-
-**Scenario:** Your team needs standardized code patterns shared across machines.
+Your team's approved patterns - auth middleware, error handlers, configs - stored once in a shared GitHub repo, accessible by every developer on every machine.
 
 ```bash
-# Store team-approved patterns in a shared GitHub/GitLab repo
-# Then any team member can fetch them:
-
-# One-time registry setup per machine
+# One-time setup (per developer)
 bl conf --set-registry https://github.com/myteam/boiler-snippets
 
-# Fetch and save to local store (reusable offline after)
-bl add jwtHelper -r
-bl add validation -r
+# Any developer pulls approved patterns
+bl add jwtAuth -r          # Saves to local store, reusable offline
 bl add rateLimiter -r
+bl add mongoConfig -r
 
-# Or one-shot without saving to local store
-bl use https://github.com/myteam/boiler-snippets:js/jwtHelper.js
+# Or one-shot (no local caching)
+bl use myteam/boiler-snippets:middleware/auth.js ./src/middleware
 ```
 
-**Benefit:** Code consistency across the entire team, across machines - no manual file sharing needed.
+**Benefit:** Every service uses the *exact same* battle-tested code. No more copy-paste drift between microservices.
 
 ---
 
-## 7. Versioned Code Evolution
+## 5. Local Project Snippets & Automation
 
-**Scenario:** You improve a utility and want to keep both versions.
+For project-specific templates you don't want in your global store, use **Local Scoped Stores**.
 
 ```bash
-# Store version 1
+# Initialize local config (sets scope: local)
+bl init -c
+```
+
+This creates a `boiler.local.json` at your project root with `"scope": "local"`. Now Boiler uses `bl/` directory instead of `~/.boiler/`:
+
+```
+my-project/
+├── boiler.local.json      ← scope: local
+└── bl/
+    ├── commands/
+    │   └── cmp.bl         ← bl new cmp <name>
+    └── snippets/
+        └── component.jsx  ← local template
+```
+
+```bash
+# All commands automatically use local store
+bl new cmp Button
+# → Scaffolds src/components/Button.jsx using bl/snippets/component.jsx
+```
+
+---
+
+## 6. Reuse Without Reinstalling Packages
+
+Before adding a 1.4MB package for one utility function, check your store:
+
+```bash
+# Store once (anywhere you write it)
+bl store utils/debounce.js
+bl store utils/deepClone.js
+bl store utils/formatDate.js
+
+# Reuse in any project, no npm needed
+bl add debounce ./src/utils
+bl add deepClone ./src/utils
+```
+
+```javascript
+// debounce.js - your template
+// __var bl__WAIT = 300
+function debounce(fn, wait = bl__WAIT) {
+  let t;
+  return (...args) => { clearTimeout(t); t = setTimeout(() => fn(...args), wait); };
+}
+export default debounce;
+```
+
+---
+
+## 7. Config Files - Same Setup Every Project
+
+```bash
+# Store your preferred configs
+bl store .eslintrc.json
+bl store .prettierrc
+bl store tsconfig.json
+bl store Dockerfile
+
+# New project setup in seconds
+bl add eslintrc .
+bl add prettierrc .
+bl add tsconfig .
+bl add Dockerfile .
+```
+
+---
+
+## 8. Versioned Code Evolution
+
+Store multiple versions, use the right one per project:
+
+```bash
+# Store v1
 bl store utils/emailService.js
 # → Saved as emailService@1.js
 
-# Later, improve it and store v2
-# Update __version to 2 in file comments
+# Improve it later, update __version to 2
 bl store utils/emailService.js
 # → Saved as emailService@2.js
 
-# Use specific versions
-bl add emailService@1  # Old projects
-bl add emailService@2  # New projects
+bl add emailService@1    # Legacy projects
+bl add emailService@2    # New projects
 ```
-
-**When to use:** Gradual migration without breaking old projects.
 
 ---
 
-## 8. Cross-Language Snippets
-
-**Scenario:** You work in multiple languages and want to store patterns for all.
+## 9. DevOps Scripts & CI Templates
 
 ```bash
-# Python async wrapper
-bl init -n
-# → Create asyncWrapper.py with __author and __version
-bl store asyncWrapper.py
-
-# JavaScript promise handler
-bl init -n
-# → Create promiseHandler.js
-bl store promiseHandler.js
-
-# Go error wrapper
-bl init -n
-# → Create errorWrapper.go
-bl store errorWrapper.go
-```
-
-**Perfect for:** Polyglot developers managing multiple tech stacks.
-
----
-
-## 9. Configuration Files
-
-**Scenario:** You use the same ESLint, Prettier, or Docker configs everywhere.
-
-```bash
-# Store configs
-bl store .eslintrc.json
-bl store .prettierrc
-bl store Dockerfile
-
-# Add to new projects
-bl add eslintrc
-bl add prettierrc
-bl add Dockerfile
-```
-
-**Saves time on:** Project setup and maintaining consistency.
-
----
-
-## 10. Testing Utilities
-
-**Scenario:** You have custom test helpers and fixtures.
-
-```bash
-# Store test utilities
-bl store tests/helpers/mockData.js
-bl store tests/helpers/testSetup.js
-
-# Add to new test suites
-bl add mockData
-bl add testSetup
-```
-
-**Why:** Faster test setup with proven patterns.
-
----
-
-## 11. Quick Script Deployment
-
-**Scenario:** You have shell scripts for deployment, backups, or automation.
-
-```bash
-# Store scripts
+# Store your deployment scripts
 bl store scripts/deploy.sh
-bl store scripts/db-backup.sh
+bl store scripts/backup.sh
+bl store .github/workflows/ci.yml
 
-# Use in CI/CD or other projects
-bl add deploy
-bl add db-backup
+# Reuse across services
+bl add deploy ./scripts
+bl add ci .github/workflows
 ```
-
-**Use for:** DevOps automation and deployment pipelines.
-
----
-
-## Best Practices
-
-### 1. **Initialize Before Storing**
-Always run `bl init` to add metadata (author, version, description) before storing.
-
-### 2. **Use Descriptive Names**
-```bash
-# Bad
-bl store helper.js
-
-# Good
-bl store jwtTokenHelper.js
-```
-
-### 3. **Version Strategically**
-- Increment version for breaking changes
-- Keep old versions for legacy projects
-
-### 4. **Store Stacks with Proper Ignore Patterns**
-Edit `boiler.stack.json` to exclude:
-```json
-{
-  "ignore": [
-    "node_modules",
-    ".env",
-    "dist",
-    ".git"
-  ]
-}
-```
-
-### 5. **Search Before Creating**
-```bash
-bl search jwt
-# Check if similar utility already exists
-```
-
----
-
-## Common Workflows
-
-### New Project Setup
-```bash
-# Add stack template
-bl add express-api
-
-# Add common utilities
-bl add errorHandler
-bl add logger
-bl add dbConfig
-
-# Start coding
-npm install
-npm start
-```
-
-### Microservice Development
-```bash
-# Store shared middleware once
-bl store auth.middleware.js
-bl store cors.middleware.js
-
-# Use across all services
-cd user-service && bl add auth && bl add cors
-cd order-service && bl add auth && bl add cors
-cd payment-service && bl add auth && bl add cors
-```
-
----
-
-### Personal Code Library
-```bash
-# Store everything you frequently use
-bl store utils/*
-
-# List your library
-bl ls
-
-# Add what you need
-bl add <snippet-name>
-```
-
----
-
-## Tips & Tricks
-
-1. **Alias frequently used snippets:**
-   ```bash
-   bl config  # Edit config
-   # Add aliases for quick access
-   ```
-
-2. **Search with keywords:**
-   ```bash
-   bl search middleware
-   bl search validation
-   ```
-
-3. **Check info before adding:**
-   ```bash
-   bl info auth@2
-   # See author, version, description
-   ```
-
-4. **Clean unused resources:**
-   ```bash
-   bl clean --snippets
-   bl clean --stacks
-   ```
 
 ---
 
 ## Next Steps
 
-- [Quick Start Guide](/guides/quickstart/) - Get started in 5 minutes
-- [Commands Reference](/commands/bl/) - Complete command documentation
-- [Installation](/guides/installation/) - Setup instructions
+- [Project Structure](/guides/project-structure/) - How `bl/` and `boiler/` work together
+- [Boiler Scripts (.bl)](/guides/bl-scripts/) - Write full automation pipelines
+- [Remote Fetching](/guides/remote-fetching/) - Fetch from anywhere
+- [Commands Reference](/commands/bl/) - Complete reference

--- a/web/src/content/docs/index.mdx
+++ b/web/src/content/docs/index.mdx
@@ -1,10 +1,10 @@
 ---
 title: Welcome to Boiler
-description: A modern CLI for managing code snippets and project templates with automatic versioning
+description: The code automation engine for developers - fetch, scaffold, and reuse code across every project
 template: splash
 hero:
   title: <span class="hero-gradient-title">Code Once. Reuse Forever.</span>
-  tagline: Store, version, and reuse code snippets across all your projects. Stop copy-pasting, start organizing.
+  tagline: Fetch code from anywhere. Scaffold full features in one command. Reuse everything across every project.
   image:
     file: ../../../public/hero-illustration.svg
     alt: Boiler CLI terminal animation
@@ -26,39 +26,63 @@ import InstallTabs from '../../components/InstallTabs.astro';
 
 <InstallTabs />
 
-## Why Boiler?
-
-Stop copy-pasting code between projects. Stop maintaining scattered snippets in random files. **Boiler is your centralized code library** - store once, use everywhere.
-
-<CardGrid stagger>
-	<Card title="Smart Versioning" icon="puzzle">
-		Automatic version management with intelligent prompts. Overwrite or create new versions - you choose.
-	</Card>
-	<Card title="Blazing Fast" icon="rocket">
-		Written in Go for maximum performance. Store and retrieve in milliseconds.
-	</Card>
-	<Card title="Template Variables" icon="pencil">
-		Dynamic snippets with customizable variables. One template, infinite configurations.
-	</Card>
-	<Card title="Universal" icon="translate">
-		Works with any language or file type.configs, Docker - everything.
-	</Card>
-	<Card title="Full Stacks" icon="open-book">
-		Store entire project templates. Express apps, React boilerplates, anything.
-	</Card>
-	<Card title="Zero Clutter" icon="approve-check">
-		Metadata stripped automatically. Get clean, production-ready code.
-	</Card>
-</CardGrid>
-
 ## See It in Action
 
-### Store a Snippet with Variables
+<div class="terminal-showcase">
+
+```bash
+# Instant .gitignore for any language
+bl gi Node
+bl gi Python
+bl gi Go
+
+# Pull any file from GitHub - no git clone
+bl use alice/snippets:js/errorHandler.js ./src/utils
+
+# Scaffold a full feature (route + controller + api wiring)
+bl new feat user
+
+# Store once, reuse forever
+bl add debounce ./src/utils
+```
+
+</div>
+
+### Instant `.gitignore` -  500+ Templates, One Command
+
+```bash
+bl gi Node        # Node.js gitignore
+bl gi Python      # Python gitignore
+bl gi Go          # Go gitignore
+bl gi Global/macOS  # macOS global gitignore
+```
+No copy-paste from gitignore.io. No browser. Just run and done.
+
+### Pull Any File from GitHub - Without `git clone`
+
+```bash
+# Grab a file from any repo
+bl use alice/snippets:js/errorHandler.js ./src/utils
+
+# Grab an entire folder as a template
+bl use vercel/next.js:examples/blog ./my-blog
+
+# From GitLab or any direct URL
+bl use https://gitlab.com/myorg/templates:Dockerfile .
+```
+
+### Scaffold an Entire Feature in One Command
+
+```bash
+bl new feat user
+```
+
+Creates `user.route.js`, `user.controller.js` and automatically injects the imports and routes into your `api.js` - all from a single `.bl` script.
+
+### Store Once. Reuse Forever.
 
 ```javascript
-// errorHandler.js
-// __author John Doe
-// __desc Custom error handler with logging
+// errorHandler.js - your template
 // __var bl__LOG_LEVEL = error
 // __var bl__NOTIFY_EMAIL = admin@example.com
 
@@ -69,49 +93,54 @@ function handleError(err) {
 ```
 
 ```bash
-# Store it
-bl store errorHandler.js
-# ✓ Stored snippet 'errorHandler@1.js'
-```
-
-### Use It Anywhere
-
-```bash
+bl store errorHandler.js        # Store it once
+# ---
 cd ~/new-project
-bl add errorHandler
-
-# Template variables found:
+bl add errorHandler ./src/utils
 #   bl__LOG_LEVEL [error]: warn
 #   bl__NOTIFY_EMAIL [admin@example.com]: dev@myapp.com
-# ✓ Added snippet 'errorHandler' to ./errorHandler.js
+# ✓ Added snippet → ./src/utils/errorHandler.js
 ```
 
-**Result:** Clean code with your custom values, no metadata comments!
+Clean code, variables replaced, metadata stripped automatically.
 
-### Store Entire Projects
+---
 
-```bash
-# Prepare your project template
-cd ./express-api
-bl init          # creates boiler.stack.json (fills in name, version, ignore)
-bl store         # stores it
+## Why Boiler?
 
-# Use it for new projects
-mkdir my-new-api && cd my-new-api
-bl add express-api
-# ✓ Added stack 'express-api' to .
-```
+<CardGrid stagger>
+	<Card title="Fetch From Anywhere" icon="rocket">
+		Pull files, folders, or entire repos from GitHub, GitLab, Bitbucket, or any URL - no `git clone`, no zip downloads.
+	</Card>
+	<Card title="Automation Pipelines" icon="puzzle">
+		Write `.bl` scripts that scaffold multiple files, inject code into existing files, and run commands - all from one `bl new` command.
+	</Card>
+	<Card title="Template Variables" icon="pencil">
+		Dynamic snippets with `bl__VAR_NAME` placeholders. Prompted interactively or injected automatically from scripts.
+	</Card>
+	<Card title="Built-in Aliases" icon="approve-check">
+		The `gi` alias gives you 500+ gitignore templates instantly. Build your own aliases with `bl alias` for any repetitive command.
+	</Card>
+	<Card title="Language & Framework Agnostic" icon="translate">
+		JS, Python, Go, Rust, Java, Docker, Kubernetes - any file type, any language, any framework. Even works with config files.
+	</Card>
+	<Card title="Local & Global Stores" icon="open-book">
+		Use a global `~/.boiler` store for shared utilities or a project-local `bl/` store with `boiler.local.json` for project-specific templates.
+	</Card>
+</CardGrid>
+
+---
 
 ## Built for Developers
 
 <CardGrid>
 	<Card title="For Solo Developers" icon="star">
-		Build your personal snippet library. Never rewrite the same code twice.
+		Your personal code library. Never rewrite the same utility, config, or component twice.
 	</Card>
 	<Card title="For Teams" icon="github">
-		Share standardized code templates. Keep team code consistent.
+		Host a shared registry on GitHub. Every developer pulls the same battle-tested templates with one command.
 	</Card>
-	<Card title="For Learners" icon="laptop">
-		Store useful patterns and examples. Build your reference collection.
+	<Card title="For Every Stack" icon="laptop">
+		Node, Python, Go, Rust, Java, C++, Docker - Boiler works wherever you write code.
 	</Card>
 </CardGrid>


### PR DESCRIPTION
## What's in this PR

### Engine Core
- `.bl` script parser and executor - run automation with `bl new <script>`
- Variable modifiers: `.lowercase()`, `.capitalize()`, `.pascalCase()` etc.
- `#if` / `#else` / `#endif` conditional logic (no AST, blazing fast)
- Code injection into existing files via `inject` command (`-d`, `-a`, `-p`, `-c` flags)

### Silent Automation Pipeline
- `BOILER_VAR_*` environment variable propagation to child commands
- Auto-skip variable prompts when values are pre-filled via config or env
- Enables fully automated, Hygen-style scaffolding pipelines

### Local Scoped Store
- `boiler.local.json` + `scope: local` support for project-specific templates
- Dynamic project root resolution - `bl new` works from any subdirectory
- Separated global (`~/.boiler`) and local (`bl/`) directory constants

### Bug Fixes
- `bl use` now fully processes templates (variables, prompts, metadata stripping)
- Remote registry path resolution fixed (no more `snippet does not have a valid remote location`)
- Config JSON parse errors now surface immediately instead of silently falling back to global scope

### Documentation
- Full website docs overhaul - homepage, README, usecases, introduction, quickstart
- New **Best Practices** guide
- Fixed markdown tables with HTML (GFM disabled in Astro config)
- Corrected `bl__varname` syntax docs (was incorrectly documented as `:varname`)
