### PR TITLE
fix(use): validate destination before downloading remote template

### DIFF
--- a/internal/cli/add/local.go
+++ b/internal/cli/add/local.go
@@ -102,6 +102,36 @@ func AddStack(st *store.Store, name, destPath string, opts Options, logger *util
 	return nil
 }
 
+// validateStackDestination reports whether a non-spread stack placement would
+// conflict with an existing path. Call this before any remote download so
+// boiler use / bl add --remote fail fast without network I/O (issue #61).
+//
+// Spread mode still needs stack contents for per-file conflict checks, so this
+// only guards the non-spread dest/stackDir path (and a non-directory dest when
+// --spread is set).
+func validateStackDestination(stackName, destPath string, opts Options) error {
+	if opts.Force {
+		return nil
+	}
+
+	if opts.Spread {
+		if utils.FileExists(destPath) && !utils.IsDirectory(destPath) {
+			return fmt.Errorf("destination '%s' must be a directory", destPath)
+		}
+		return nil
+	}
+
+	stackDir := stackDirectoryName(stackName)
+	if opts.Name != "" {
+		stackDir = opts.Name
+	}
+	finalDestPath := filepath.Join(destPath, stackDir)
+	if utils.FileExists(finalDestPath) {
+		return fmt.Errorf(utils.ErrDestAlreadyExists, finalDestPath)
+	}
+	return nil
+}
+
 func copyStackToDestination(stackPath, stackName, destPath string, opts Options) (string, error) {
 	ignorePatterns := utils.DefaultIgnorePatterns
 
@@ -115,14 +145,15 @@ func copyStackToDestination(stackPath, stackName, destPath string, opts Options)
 		return destPath, nil
 	}
 
+	if err := validateStackDestination(stackName, destPath, opts); err != nil {
+		return "", err
+	}
+
 	stackDir := stackDirectoryName(stackName)
 	if opts.Name != "" {
 		stackDir = opts.Name
 	}
 	finalDestPath := filepath.Join(destPath, stackDir)
-	if utils.FileExists(finalDestPath) && !opts.Force {
-		return "", fmt.Errorf(utils.ErrDestAlreadyExists, finalDestPath)
-	}
 
 	if err := utils.CopyDir(stackPath, finalDestPath, ignorePatterns); err != nil {
 		return "", fmt.Errorf("failed to copy stack: %w", err)

--- a/internal/cli/add/local_test.go
+++ b/internal/cli/add/local_test.go
@@ -3,6 +3,7 @@ package add
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rishiyaduwanshi/boiler/internal/utils"
@@ -76,6 +77,61 @@ func TestCopyStackToDestination_Spread(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(dest, "server.js")); err != nil {
 		t.Fatalf("expected file copied into destination root: %v", err)
+	}
+}
+
+func TestValidateStackDestination_ExistsWithoutForce(t *testing.T) {
+	t.Parallel()
+
+	destRoot := t.TempDir()
+	// Non-spread places the stack in destRoot/<stackDir>
+	conflict := filepath.Join(destRoot, "my-stack")
+	if err := os.Mkdir(conflict, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := validateStackDestination("alice/my-stack", destRoot, Options{Force: false})
+	if err == nil {
+		t.Fatal("expected destination-exists error, got nil")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("error %q should mention already exists", err)
+	}
+}
+
+func TestValidateStackDestination_ForceSkipsCheck(t *testing.T) {
+	t.Parallel()
+
+	destRoot := t.TempDir()
+	conflict := filepath.Join(destRoot, "my-stack")
+	if err := os.Mkdir(conflict, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateStackDestination("alice/my-stack", destRoot, Options{Force: true}); err != nil {
+		t.Fatalf("force should skip existence check, got: %v", err)
+	}
+}
+
+func TestValidateStackDestination_Available(t *testing.T) {
+	t.Parallel()
+
+	destRoot := t.TempDir()
+	if err := validateStackDestination("alice/my-stack", destRoot, Options{}); err != nil {
+		t.Fatalf("empty dest should be available, got: %v", err)
+	}
+}
+
+func TestValidateStackDestination_CustomName(t *testing.T) {
+	t.Parallel()
+
+	destRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(destRoot, "custom"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	err := validateStackDestination("alice/my-stack", destRoot, Options{Name: "custom"})
+	if err == nil {
+		t.Fatal("expected conflict on custom name")
 	}
 }
 

--- a/internal/cli/add/local_test.go
+++ b/internal/cli/add/local_test.go
@@ -84,13 +84,14 @@ func TestValidateStackDestination_ExistsWithoutForce(t *testing.T) {
 	t.Parallel()
 
 	destRoot := t.TempDir()
-	// Non-spread places the stack in destRoot/<stackDir>
+	// Non-spread places the stack in destRoot/<stackDir>.
+	// stackDirectoryName strips versions but keeps plain stack names as-is.
 	conflict := filepath.Join(destRoot, "my-stack")
 	if err := os.Mkdir(conflict, 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	err := validateStackDestination("alice/my-stack", destRoot, Options{Force: false})
+	err := validateStackDestination("my-stack", destRoot, Options{Force: false})
 	if err == nil {
 		t.Fatal("expected destination-exists error, got nil")
 	}
@@ -108,7 +109,7 @@ func TestValidateStackDestination_ForceSkipsCheck(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := validateStackDestination("alice/my-stack", destRoot, Options{Force: true}); err != nil {
+	if err := validateStackDestination("my-stack", destRoot, Options{Force: true}); err != nil {
 		t.Fatalf("force should skip existence check, got: %v", err)
 	}
 }
@@ -117,7 +118,7 @@ func TestValidateStackDestination_Available(t *testing.T) {
 	t.Parallel()
 
 	destRoot := t.TempDir()
-	if err := validateStackDestination("alice/my-stack", destRoot, Options{}); err != nil {
+	if err := validateStackDestination("my-stack", destRoot, Options{}); err != nil {
 		t.Fatalf("empty dest should be available, got: %v", err)
 	}
 }
@@ -129,7 +130,7 @@ func TestValidateStackDestination_CustomName(t *testing.T) {
 	if err := os.Mkdir(filepath.Join(destRoot, "custom"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	err := validateStackDestination("alice/my-stack", destRoot, Options{Name: "custom"})
+	err := validateStackDestination("my-stack", destRoot, Options{Name: "custom"})
 	if err == nil {
 		t.Fatal("expected conflict on custom name")
 	}

--- a/internal/cli/add/remote.go
+++ b/internal/cli/add/remote.go
@@ -119,6 +119,11 @@ func ResourceFromRemote(resource, destPath string, resourceType ResourceType, no
 		return fmt.Errorf("stack '%s' does not have a valid remote location", resource)
 	}
 
+	// Fail before any network call when the destination already exists.
+	if err := validateStackDestination(resource, destPath, opts); err != nil {
+		return err
+	}
+
 	if noStore {
 		tempStackPath, err := os.MkdirTemp("", "boiler-remote-stack-*")
 		if err != nil {
@@ -277,6 +282,12 @@ func directRemoteResource(remotePath, destPath string, resourceType ResourceType
 		return AddSnippet(st, resourceName, destPath, opts, cfg, logger)
 	}
 
+	resourceName := repo
+	// Fail before any network call when the destination already exists.
+	if err := validateStackDestination(resourceName, destPath, opts); err != nil {
+		return err
+	}
+
 	if noStore {
 		tempStackPath, err := os.MkdirTemp("", "boiler-direct-stack-*")
 		if err != nil {
@@ -288,7 +299,6 @@ func directRemoteResource(remotePath, destPath string, resourceType ResourceType
 			return err
 		}
 
-		resourceName := repo
 		finalDestPath, err := copyStackToDestination(tempStackPath, resourceName, destPath, opts)
 		if err != nil {
 			return err
@@ -311,9 +321,6 @@ func directRemoteResource(remotePath, destPath string, resourceType ResourceType
 	if err := remote.FetchStack(remotePath, localStackPath); err != nil {
 		return err
 	}
-
-	// Generate resource name: repo name
-	resourceName := repo
 
 	// Add to local store metadata
 	st, err := utils.LoadStore(cfg.Paths.Store)
@@ -389,6 +396,11 @@ func directRemoteURLResource(remotePath, destPath string, resourceType ResourceT
 	}
 
 	resourceName := utils.StackNameFromRemoteURL(remotePath)
+	// Fail before any network call when the destination already exists.
+	if err := validateStackDestination(resourceName, destPath, opts); err != nil {
+		return err
+	}
+
 	if noStore {
 		tempStackPath, err := os.MkdirTemp("", "boiler-url-stack-*")
 		if err != nil {

--- a/internal/cli/add/remote_test.go
+++ b/internal/cli/add/remote_test.go
@@ -1,7 +1,15 @@
 package add
 
 import (
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
 	"testing"
+
+	"github.com/rishiyaduwanshi/boiler/internal/config"
 )
 
 func TestShouldTreatDirectRemotePathAsSnippet(t *testing.T) {
@@ -49,6 +57,110 @@ func TestShouldTreatDirectURLAsSnippet(t *testing.T) {
 			got := shouldTreatDirectURLAsSnippet(tt.resourceURL, tt.resourceType)
 			if got != tt.want {
 				t.Fatalf("shouldTreatDirectURLAsSnippet(%q, %v) = %v, want %v", tt.resourceURL, tt.resourceType, got, tt.want)
+			}
+		})
+	}
+}
+
+// countingRoundTripper records HTTP attempts. Used to assert that remote
+// pre-fetch validation fails before any download/network call.
+type countingRoundTripper struct {
+	hits atomic.Int64
+}
+
+func (c *countingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	c.hits.Add(1)
+	return nil, fmt.Errorf("unexpected network call to %s (test transport)", req.URL)
+}
+
+func testRemoteAddConfig(t *testing.T) *config.Config {
+	t.Helper()
+	root := t.TempDir()
+	return &config.Config{
+		Paths: &config.Paths{
+			Root:     root,
+			Store:    filepath.Join(root, "store"),
+			Snippets: filepath.Join(root, "store", "snippets"),
+			Stacks:   filepath.Join(root, "store", "stacks"),
+			Logs:     filepath.Join(root, "logs"),
+			Bin:      filepath.Join(root, "bin"),
+		},
+		Vars:    map[string]string{},
+		Aliases: map[string]string{},
+	}
+}
+
+// TestResourceFromRemote_OccupiedDestSkipsFetch exercises the remote stack
+// add path (ResourceFromRemote → directRemote*) and asserts that destination
+// validation fails before any FetchStack/network download. Covers both
+// stored and --no-store flows so a future call-order regression is caught.
+func TestResourceFromRemote_OccupiedDestSkipsFetch(t *testing.T) {
+	// Mutates http.DefaultTransport; do not run in parallel with other tests
+	// that perform real HTTP.
+	transport := &countingRoundTripper{}
+	prev := http.DefaultTransport
+	http.DefaultTransport = transport
+	defer func() { http.DefaultTransport = prev }()
+
+	cfg := testRemoteAddConfig(t)
+
+	tests := []struct {
+		name      string
+		resource  string
+		stackDir  string // dest/<stackDir> conflict path
+		noStore   bool
+		forceType ResourceType
+	}{
+		{
+			name:      "direct owner/repo stored",
+			resource:  "alice/my-stack",
+			stackDir:  "my-stack", // directRemoteResource uses repo as stack name
+			noStore:   false,
+			forceType: ResourceTypeStack,
+		},
+		{
+			name:      "direct owner/repo no-store",
+			resource:  "alice/my-stack",
+			stackDir:  "my-stack",
+			noStore:   true,
+			forceType: ResourceTypeStack,
+		},
+		{
+			name:      "direct archive URL stored",
+			resource:  "https://example.com/archives/demo-stack.zip",
+			stackDir:  "demo-stack",
+			noStore:   false,
+			forceType: ResourceTypeStack,
+		},
+		{
+			name:      "direct archive URL no-store",
+			resource:  "https://example.com/archives/demo-stack.zip",
+			stackDir:  "demo-stack",
+			noStore:   true,
+			forceType: ResourceTypeStack,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			destRoot := t.TempDir()
+			conflict := filepath.Join(destRoot, tt.stackDir)
+			if err := os.Mkdir(conflict, 0755); err != nil {
+				t.Fatal(err)
+			}
+
+			before := transport.hits.Load()
+			err := ResourceFromRemote(tt.resource, destRoot, tt.forceType, tt.noStore, Options{}, cfg, nil)
+			after := transport.hits.Load()
+
+			if err == nil {
+				t.Fatal("expected destination-exists error, got nil")
+			}
+			if !strings.Contains(err.Error(), "already exists") {
+				t.Fatalf("error %q should mention already exists", err)
+			}
+			if after != before {
+				t.Fatalf("expected no network/FetchStack after dest conflict; HTTP hits %d -> %d", before, after)
 			}
 		})
 	}

--- a/internal/cli/use/cmd.go
+++ b/internal/cli/use/cmd.go
@@ -78,6 +78,9 @@ Stack placement:
 			AsSnippet: useAsSnippet,
 		}
 
+		// Destination conflict checks for remote stacks run inside AddResource
+		// (validateStackDestination) before any download, so --force is not
+		// required to discover an existing path. See issue #61.
 		if err := addcmd.AddResource(resource, addcmd.ResolveDestination(positionalDest), true, true, opts, cfg, logger); err != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 			os.Exit(1)


### PR DESCRIPTION
## Summary

`boiler use` (and remote stack add paths) currently fetch the template first and only then fail with `destination already exists`. This PR validates the final stack placement **before** any remote download when `--force` is not set.

Fixes #61

## Changes

- Add `validateStackDestination` for non-spread `dest/<stackDir>` conflicts (and non-directory dest under `--spread`)
- Call it before every remote stack `FetchStack` path in `remote.go`
- Reuse it from `copyStackToDestination` so local add stays consistent
- Unit tests for exists / force / available / custom `--name`
- Comment in `use` command documenting pre-fetch check behavior

## Test plan

- [x] Unit tests in `internal/cli/add` for `validateStackDestination`
- [x] CI `go test` on the PR
- Manual: with an existing `src/<stack>` dir, `boiler use <remote> src` should error immediately without fetch logs

## Commit style

Conventional: `fix(use): validate stack destination before remote download`
