### PR TITLE
feat(remote): add Git LFS clone fallback

### DIFF
--- a/internal/remote/fetch.go
+++ b/internal/remote/fetch.go
@@ -128,7 +128,7 @@ func FetchStack(remotePath string, destPath string) error {
 				}
 				defer os.RemoveAll(tempDir)
 
-				if cloneErr := fetchStackWithGitClone(p, owner, repo, ref, subPath, hasExplicitRef, tempDir, destPath); cloneErr != nil {
+				if cloneErr := fetchStackWithGitClone(p, owner, repo, ref, subPath, tempDir, destPath); cloneErr != nil {
 					return fmt.Errorf("failed to fetch Git LFS stack: %w", cloneErr)
 				}
 			}
@@ -222,7 +222,7 @@ func FetchStack(remotePath string, destPath string) error {
 	}
 	if hasPointers {
 		fmt.Println(utils.MsgGitLFSFallback)
-		if err := fetchStackWithGitClone(p, owner, repo, ref, subPath, hasExplicitRef, tempDir, destPath); err != nil {
+		if err := fetchStackWithGitClone(p, owner, repo, ref, subPath, tempDir, destPath); err != nil {
 			return fmt.Errorf("failed to fetch Git LFS stack: %w", err)
 		}
 		fmt.Printf("✓ Stack downloaded successfully\n")

--- a/internal/remote/fetch.go
+++ b/internal/remote/fetch.go
@@ -116,6 +116,22 @@ func FetchStack(remotePath string, destPath string) error {
 
 	if owner != "" && repo != "" && subPath != "." {
 		if err := fetchProviderSubPath(p, owner, repo, ref, subPath, destPath); err == nil {
+			hasPointers, scanErr := hasGitLFSPointers(destPath)
+			if scanErr != nil {
+				return fmt.Errorf("failed to scan fetched stack for Git LFS pointers: %w", scanErr)
+			}
+			if hasPointers {
+				fmt.Println(utils.MsgGitLFSFallback)
+				tempDir, tempErr := os.MkdirTemp("", "boiler-stack-clone-*")
+				if tempErr != nil {
+					return fmt.Errorf("failed to create temp directory: %w", tempErr)
+				}
+				defer os.RemoveAll(tempDir)
+
+				if cloneErr := fetchStackWithGitClone(p, owner, repo, ref, subPath, hasExplicitRef, tempDir, destPath); cloneErr != nil {
+					return fmt.Errorf("failed to fetch Git LFS stack: %w", cloneErr)
+				}
+			}
 			fmt.Printf("✓ Stack downloaded successfully\n")
 			return nil
 		} else {
@@ -198,6 +214,19 @@ func FetchStack(remotePath string, destPath string) error {
 		} else {
 			sourceDir = filepath.Join(extractDir, subPath)
 		}
+	}
+
+	hasPointers, err := hasGitLFSPointers(sourceDir)
+	if err != nil {
+		return fmt.Errorf("failed to scan extracted stack for Git LFS pointers: %w", err)
+	}
+	if hasPointers {
+		fmt.Println(utils.MsgGitLFSFallback)
+		if err := fetchStackWithGitClone(p, owner, repo, ref, subPath, hasExplicitRef, tempDir, destPath); err != nil {
+			return fmt.Errorf("failed to fetch Git LFS stack: %w", err)
+		}
+		fmt.Printf("✓ Stack downloaded successfully\n")
+		return nil
 	}
 
 	if err := utils.CopyDir(sourceDir, destPath, nil); err != nil {

--- a/internal/remote/lfs.go
+++ b/internal/remote/lfs.go
@@ -85,13 +85,52 @@ func gitCloneArgs(cloneURL, ref, dest string) []string {
 }
 
 func cloneGitRepository(cloneURL, ref, dest string) error {
-	cmd := exec.Command("git", gitCloneArgs(cloneURL, ref, dest)...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if isCommitSHA(ref) {
+		return cloneGitCommit(cloneURL, ref, dest)
+	}
+
+	if err := runGit(gitCloneArgs(cloneURL, ref, dest)...); err != nil {
 		return fmt.Errorf("git clone failed: %w", err)
 	}
 	return nil
+}
+
+func isCommitSHA(ref string) bool {
+	if len(ref) != 40 && len(ref) != 64 {
+		return false
+	}
+	for _, char := range ref {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+			return false
+		}
+	}
+	return true
+}
+
+func cloneGitCommit(cloneURL, ref, dest string) error {
+	steps := []struct {
+		name string
+		args []string
+	}{
+		{name: "init", args: []string{"init", dest}},
+		{name: "remote add", args: []string{"-C", dest, "remote", "add", "origin", cloneURL}},
+		{name: "fetch", args: []string{"-C", dest, "fetch", "--depth", "1", "origin", ref}},
+		{name: "checkout", args: []string{"-C", dest, "checkout", "--detach", "FETCH_HEAD"}},
+	}
+
+	for _, step := range steps {
+		if err := runGit(step.args...); err != nil {
+			return fmt.Errorf("git %s failed: %w", step.name, err)
+		}
+	}
+	return nil
+}
+
+func runGit(args ...string) error {
+	cmd := exec.Command("git", args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func fetchStackWithGitClone(p Provider, owner, repo, ref, subPath, tempDir, destPath string) error {

--- a/internal/remote/lfs.go
+++ b/internal/remote/lfs.go
@@ -1,0 +1,132 @@
+package remote
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/rishiyaduwanshi/boiler/internal/constants"
+	"github.com/rishiyaduwanshi/boiler/internal/utils"
+)
+
+const gitLFSPointerHeader = "version https://git-lfs.github.com/spec/v1"
+
+var runGitClone = cloneGitRepository
+
+func hasGitLFSPointers(dir string) (bool, error) {
+	errFound := errors.New("git lfs pointer found")
+	err := filepath.WalkDir(dir, func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !entry.Type().IsRegular() {
+			return nil
+		}
+
+		file, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+
+		buf := make([]byte, len(gitLFSPointerHeader)+2)
+		n, readErr := io.ReadFull(file, buf)
+		closeErr := file.Close()
+		if readErr != nil && readErr != io.EOF && readErr != io.ErrUnexpectedEOF {
+			return readErr
+		}
+		if closeErr != nil {
+			return closeErr
+		}
+
+		firstLine := strings.SplitN(string(buf[:n]), "\n", 2)[0]
+		if strings.TrimSuffix(firstLine, "\r") == gitLFSPointerHeader {
+			return errFound
+		}
+		return nil
+	})
+	if errors.Is(err, errFound) {
+		return true, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return false, nil
+}
+
+func providerCloneURL(p Provider, owner, repo string) (string, error) {
+	repo = strings.TrimSuffix(repo, ".git")
+	if owner == "" || repo == "" {
+		return "", fmt.Errorf("remote does not identify a cloneable repository; cannot fall back to git clone")
+	}
+
+	switch provider := p.(type) {
+	case githubProvider:
+		return fmt.Sprintf("%s%s/%s/%s.git", constants.SchemeHTTPS, constants.ProviderGithubHost, owner, repo), nil
+	case gitlabProvider:
+		host := provider.host
+		if host == "" {
+			host = constants.ProviderGitlabHost
+		}
+		return fmt.Sprintf("%s%s/%s/%s.git", constants.SchemeHTTPS, host, owner, repo), nil
+	case bitbucketProvider:
+		return fmt.Sprintf("%s%s/%s/%s.git", constants.SchemeHTTPS, constants.ProviderBitbucketHost, owner, repo), nil
+	default:
+		return "", fmt.Errorf("%s remote does not identify a cloneable repository; cannot fall back to git clone", p.Name())
+	}
+}
+
+func gitCloneArgs(cloneURL, ref, dest string, explicitRef bool) []string {
+	args := []string{"clone", "--depth", "1"}
+	if explicitRef {
+		args = append(args, "--branch", ref, "--single-branch")
+	}
+	return append(args, cloneURL, dest)
+}
+
+func cloneGitRepository(cloneURL, ref, dest string, explicitRef bool) error {
+	cmd := exec.Command("git", gitCloneArgs(cloneURL, ref, dest, explicitRef)...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("git clone failed: %w", err)
+	}
+	return nil
+}
+
+func fetchStackWithGitClone(p Provider, owner, repo, ref, subPath string, explicitRef bool, tempDir, destPath string) error {
+	cloneURL, err := providerCloneURL(p, owner, repo)
+	if err != nil {
+		return err
+	}
+
+	cloneDir := filepath.Join(tempDir, "git-clone")
+	if err := runGitClone(cloneURL, ref, cloneDir, explicitRef); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(filepath.Join(cloneDir, ".git")); err != nil {
+		return fmt.Errorf("failed to remove git metadata: %w", err)
+	}
+
+	sourceDir := cloneDir
+	if subPath != "" && subPath != "." {
+		sourceDir = filepath.Join(cloneDir, filepath.FromSlash(subPath))
+	}
+
+	hasPointers, err := hasGitLFSPointers(sourceDir)
+	if err != nil {
+		return fmt.Errorf("failed to scan cloned stack for Git LFS pointers: %w", err)
+	}
+	if hasPointers {
+		return fmt.Errorf("git clone left unresolved Git LFS pointers; ensure Git LFS is installed and available")
+	}
+
+	if err := utils.CopyDir(sourceDir, destPath, nil); err != nil {
+		return fmt.Errorf("failed to copy cloned stack: %w", err)
+	}
+	return nil
+}

--- a/internal/remote/lfs.go
+++ b/internal/remote/lfs.go
@@ -1,10 +1,12 @@
 package remote
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -84,11 +86,80 @@ func gitCloneArgs(cloneURL, ref, dest string) []string {
 	return []string{"clone", "--depth", "1", "--branch", ref, "--single-branch", cloneURL, dest}
 }
 
-func cloneGitRepository(cloneURL, ref, dest string) error {
+func cloneGitRepository(p Provider, owner, repo, cloneURL, ref, dest string) error {
 	if err := runGit(gitCloneArgs(cloneURL, ref, dest)...); err == nil {
 		return nil
 	}
+	if isAbbreviatedCommitSHA(ref) {
+		resolvedRef, err := resolveAbbreviatedCommit(p, owner, repo, ref)
+		if err != nil {
+			return err
+		}
+		ref = resolvedRef
+	}
 	return cloneGitCommit(cloneURL, ref, dest)
+}
+
+func isAbbreviatedCommitSHA(ref string) bool {
+	if len(ref) < 7 || len(ref) >= 40 {
+		return false
+	}
+	return isHexObjectID(ref)
+}
+
+func resolveAbbreviatedCommit(p Provider, owner, repo, ref string) (string, error) {
+	repo = strings.TrimSuffix(repo, ".git")
+	var endpoint string
+	var field string
+
+	switch provider := p.(type) {
+	case githubProvider:
+		endpoint = fmt.Sprintf("%s%s/repos/%s/%s/commits/%s", constants.SchemeHTTPS, constants.ProviderGithubAPI, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(ref))
+		field = "sha"
+	case gitlabProvider:
+		host := provider.host
+		if host == "" {
+			host = constants.ProviderGitlabHost
+		}
+		project := url.PathEscape(owner + "/" + repo)
+		endpoint = fmt.Sprintf("%s%s/%s/%s/repository/commits/%s", constants.SchemeHTTPS, host, constants.ProviderGitlabAPI, project, url.PathEscape(ref))
+		field = "id"
+	case bitbucketProvider:
+		endpoint = fmt.Sprintf("%s%s/repositories/%s/%s/commit/%s", constants.SchemeHTTPS, constants.ProviderBitbucketAPI, url.PathEscape(owner), url.PathEscape(repo), url.PathEscape(ref))
+		field = "hash"
+	default:
+		return "", fmt.Errorf("%s does not support abbreviated commit refs in Git LFS fallback; use a full commit SHA", p.Name())
+	}
+
+	data, err := downloadFile(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve abbreviated commit %q through the %s API: %w", ref, p.Name(), err)
+	}
+
+	var payload map[string]json.RawMessage
+	if err := json.Unmarshal(data, &payload); err != nil {
+		return "", fmt.Errorf("failed to parse abbreviated commit response from the %s API: %w", p.Name(), err)
+	}
+	var resolved string
+	if err := json.Unmarshal(payload[field], &resolved); err != nil || resolved == "" {
+		return "", fmt.Errorf("the %s API response did not include a full commit SHA", p.Name())
+	}
+	if (len(resolved) != 40 && len(resolved) != 64) || !isHexObjectID(resolved) {
+		return "", fmt.Errorf("the %s API returned an invalid full commit SHA", p.Name())
+	}
+	if !strings.HasPrefix(strings.ToLower(resolved), strings.ToLower(ref)) {
+		return "", fmt.Errorf("the %s API returned a commit SHA that does not match abbreviated ref %q", p.Name(), ref)
+	}
+	return resolved, nil
+}
+
+func isHexObjectID(ref string) bool {
+	for _, char := range ref {
+		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
+			return false
+		}
+	}
+	return ref != ""
 }
 
 func cloneGitCommit(cloneURL, ref, dest string) error {
@@ -124,7 +195,7 @@ func fetchStackWithGitClone(p Provider, owner, repo, ref, subPath, tempDir, dest
 	}
 
 	cloneDir := filepath.Join(tempDir, "git-clone")
-	if err := runGitClone(cloneURL, ref, cloneDir); err != nil {
+	if err := runGitClone(p, owner, repo, cloneURL, ref, cloneDir); err != nil {
 		return err
 	}
 	if err := os.RemoveAll(filepath.Join(cloneDir, ".git")); err != nil {

--- a/internal/remote/lfs.go
+++ b/internal/remote/lfs.go
@@ -85,26 +85,10 @@ func gitCloneArgs(cloneURL, ref, dest string) []string {
 }
 
 func cloneGitRepository(cloneURL, ref, dest string) error {
-	if isCommitSHA(ref) {
-		return cloneGitCommit(cloneURL, ref, dest)
+	if err := runGit(gitCloneArgs(cloneURL, ref, dest)...); err == nil {
+		return nil
 	}
-
-	if err := runGit(gitCloneArgs(cloneURL, ref, dest)...); err != nil {
-		return fmt.Errorf("git clone failed: %w", err)
-	}
-	return nil
-}
-
-func isCommitSHA(ref string) bool {
-	if len(ref) != 40 && len(ref) != 64 {
-		return false
-	}
-	for _, char := range ref {
-		if !((char >= '0' && char <= '9') || (char >= 'a' && char <= 'f') || (char >= 'A' && char <= 'F')) {
-			return false
-		}
-	}
-	return true
+	return cloneGitCommit(cloneURL, ref, dest)
 }
 
 func cloneGitCommit(cloneURL, ref, dest string) error {

--- a/internal/remote/lfs.go
+++ b/internal/remote/lfs.go
@@ -80,16 +80,12 @@ func providerCloneURL(p Provider, owner, repo string) (string, error) {
 	}
 }
 
-func gitCloneArgs(cloneURL, ref, dest string, explicitRef bool) []string {
-	args := []string{"clone", "--depth", "1"}
-	if explicitRef {
-		args = append(args, "--branch", ref, "--single-branch")
-	}
-	return append(args, cloneURL, dest)
+func gitCloneArgs(cloneURL, ref, dest string) []string {
+	return []string{"clone", "--depth", "1", "--branch", ref, "--single-branch", cloneURL, dest}
 }
 
-func cloneGitRepository(cloneURL, ref, dest string, explicitRef bool) error {
-	cmd := exec.Command("git", gitCloneArgs(cloneURL, ref, dest, explicitRef)...)
+func cloneGitRepository(cloneURL, ref, dest string) error {
+	cmd := exec.Command("git", gitCloneArgs(cloneURL, ref, dest)...)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
@@ -98,14 +94,14 @@ func cloneGitRepository(cloneURL, ref, dest string, explicitRef bool) error {
 	return nil
 }
 
-func fetchStackWithGitClone(p Provider, owner, repo, ref, subPath string, explicitRef bool, tempDir, destPath string) error {
+func fetchStackWithGitClone(p Provider, owner, repo, ref, subPath, tempDir, destPath string) error {
 	cloneURL, err := providerCloneURL(p, owner, repo)
 	if err != nil {
 		return err
 	}
 
 	cloneDir := filepath.Join(tempDir, "git-clone")
-	if err := runGitClone(cloneURL, ref, cloneDir, explicitRef); err != nil {
+	if err := runGitClone(cloneURL, ref, cloneDir); err != nil {
 		return err
 	}
 	if err := os.RemoveAll(filepath.Join(cloneDir, ".git")); err != nil {

--- a/internal/remote/lfs_test.go
+++ b/internal/remote/lfs_test.go
@@ -174,6 +174,37 @@ func TestCloneGitRepositoryCommitSHA(t *testing.T) {
 	}
 }
 
+func TestCloneGitRepositoryPrefersHexBranch(t *testing.T) {
+	origin := t.TempDir()
+	runTestGit(t, "init", origin)
+	runTestGit(t, "-C", origin, "config", "user.name", "Boiler Test")
+	runTestGit(t, "-C", origin, "config", "user.email", "boiler@example.invalid")
+
+	contentPath := filepath.Join(origin, "content.txt")
+	if err := os.WriteFile(contentPath, []byte("branch"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runTestGit(t, "-C", origin, "add", "content.txt")
+	runTestGit(t, "-C", origin, "commit", "-m", "branch")
+
+	branch := strings.Repeat("a", 40)
+	runTestGit(t, "-C", origin, "branch", branch)
+
+	originPath := filepath.ToSlash(origin)
+	if !strings.HasPrefix(originPath, "/") {
+		originPath = "/" + originPath
+	}
+	originURL := (&url.URL{Scheme: "file", Path: originPath}).String()
+	dest := filepath.Join(t.TempDir(), "clone")
+	if err := cloneGitRepository(originURL, branch, dest); err != nil {
+		t.Fatalf("cloneGitRepository() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(runTestGit(t, "-C", dest, "branch", "--show-current")); got != branch {
+		t.Fatalf("current branch = %q, want %q", got, branch)
+	}
+}
+
 func TestProviderCloneURL(t *testing.T) {
 	t.Parallel()
 

--- a/internal/remote/lfs_test.go
+++ b/internal/remote/lfs_test.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -13,6 +14,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/rishiyaduwanshi/boiler/internal/constants"
 )
 
 type roundTripFunc func(*http.Request) (*http.Response, error)
@@ -152,7 +155,7 @@ func TestCloneGitRepositoryCommitSHA(t *testing.T) {
 	}
 	originURL := (&url.URL{Scheme: "file", Path: originPath}).String()
 	dest := filepath.Join(t.TempDir(), "clone")
-	if err := cloneGitRepository(originURL, selectedSHA, dest); err != nil {
+	if err := cloneGitRepository(githubProvider{}, "alice", "repo", originURL, selectedSHA, dest); err != nil {
 		t.Fatalf("cloneGitRepository() error = %v", err)
 	}
 
@@ -187,8 +190,86 @@ func TestCloneGitRepositoryPrefersHexBranch(t *testing.T) {
 	runTestGit(t, "-C", origin, "add", "content.txt")
 	runTestGit(t, "-C", origin, "commit", "-m", "branch")
 
-	branch := strings.Repeat("a", 40)
-	runTestGit(t, "-C", origin, "branch", branch)
+	originPath := filepath.ToSlash(origin)
+	if !strings.HasPrefix(originPath, "/") {
+		originPath = "/" + originPath
+	}
+	originURL := (&url.URL{Scheme: "file", Path: originPath}).String()
+
+	for _, branch := range []string{strings.Repeat("a", 12), strings.Repeat("b", 40)} {
+		branch := branch
+		t.Run(fmt.Sprintf("length-%d", len(branch)), func(t *testing.T) {
+			runTestGit(t, "-C", origin, "branch", branch)
+			dest := filepath.Join(t.TempDir(), "clone")
+			if err := cloneGitRepository(githubProvider{}, "alice", "repo", originURL, branch, dest); err != nil {
+				t.Fatalf("cloneGitRepository() error = %v", err)
+			}
+
+			if got := strings.TrimSpace(runTestGit(t, "-C", dest, "branch", "--show-current")); got != branch {
+				t.Fatalf("current branch = %q, want %q", got, branch)
+			}
+		})
+	}
+}
+
+func TestIsAbbreviatedCommitSHA(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		ref  string
+		want bool
+	}{
+		{ref: "abcdef", want: false},
+		{ref: "abcdef0", want: true},
+		{ref: strings.Repeat("a", 39), want: true},
+		{ref: strings.Repeat("a", 40), want: false},
+		{ref: strings.Repeat("a", 64), want: false},
+		{ref: "release1", want: false},
+	}
+
+	for _, tt := range tests {
+		caseData := tt
+		t.Run(caseData.ref, func(t *testing.T) {
+			t.Parallel()
+			if got := isAbbreviatedCommitSHA(caseData.ref); got != caseData.want {
+				t.Fatalf("isAbbreviatedCommitSHA(%q) = %v, want %v", caseData.ref, got, caseData.want)
+			}
+		})
+	}
+}
+
+func TestCloneGitRepositoryAbbreviatedCommitSHA(t *testing.T) {
+	origin := t.TempDir()
+	runTestGit(t, "init", origin)
+	runTestGit(t, "-C", origin, "config", "user.name", "Boiler Test")
+	runTestGit(t, "-C", origin, "config", "user.email", "boiler@example.invalid")
+
+	contentPath := filepath.Join(origin, "content.txt")
+	if err := os.WriteFile(contentPath, []byte("selected"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runTestGit(t, "-C", origin, "add", "content.txt")
+	runTestGit(t, "-C", origin, "commit", "-m", "selected")
+	selectedSHA := strings.TrimSpace(runTestGit(t, "-C", origin, "rev-parse", "HEAD"))
+	selectedRef := selectedSHA[:12]
+
+	if err := os.WriteFile(contentPath, []byte("latest"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runTestGit(t, "-C", origin, "add", "content.txt")
+	runTestGit(t, "-C", origin, "commit", "-m", "latest")
+
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("Authorization") != "" {
+			t.Fatal("abbreviated commit lookup unexpectedly sent credentials")
+		}
+		if req.URL.Host != constants.ProviderGithubAPI || req.URL.Path != "/repos/alice/repo/commits/"+selectedRef {
+			t.Fatalf("unexpected commit lookup URL: %s", req.URL)
+		}
+		return testHTTPResponse(http.StatusOK, fmt.Sprintf(`{"sha":%q}`, selectedSHA)), nil
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
 
 	originPath := filepath.ToSlash(origin)
 	if !strings.HasPrefix(originPath, "/") {
@@ -196,12 +277,105 @@ func TestCloneGitRepositoryPrefersHexBranch(t *testing.T) {
 	}
 	originURL := (&url.URL{Scheme: "file", Path: originPath}).String()
 	dest := filepath.Join(t.TempDir(), "clone")
-	if err := cloneGitRepository(originURL, branch, dest); err != nil {
+	if err := cloneGitRepository(githubProvider{}, "alice", "repo", originURL, selectedRef, dest); err != nil {
 		t.Fatalf("cloneGitRepository() error = %v", err)
 	}
 
-	if got := strings.TrimSpace(runTestGit(t, "-C", dest, "branch", "--show-current")); got != branch {
-		t.Fatalf("current branch = %q, want %q", got, branch)
+	if got := strings.TrimSpace(runTestGit(t, "-C", dest, "rev-parse", "HEAD")); got != selectedSHA {
+		t.Fatalf("cloned SHA = %q, want %q", got, selectedSHA)
+	}
+	if got := strings.TrimSpace(runTestGit(t, "-C", dest, "branch", "--show-current")); got != "" {
+		t.Fatalf("current branch = %q, want detached HEAD", got)
+	}
+}
+
+func TestResolveAbbreviatedCommitProviders(t *testing.T) {
+	ref := "abcdef0"
+	fullSHA := ref + strings.Repeat("1", 33)
+	tests := []struct {
+		name     string
+		provider Provider
+		wantHost string
+		wantPath string
+		response string
+	}{
+		{name: "github", provider: githubProvider{}, wantHost: constants.ProviderGithubAPI, wantPath: "/repos/alice/repo/commits/" + ref, response: fmt.Sprintf(`{"sha":%q}`, fullSHA)},
+		{name: "gitlab", provider: gitlabProvider{host: constants.ProviderGitlabHost}, wantHost: constants.ProviderGitlabHost, wantPath: "/api/v4/projects/alice%2Frepo/repository/commits/" + ref, response: fmt.Sprintf(`{"id":%q}`, fullSHA)},
+		{name: "bitbucket", provider: bitbucketProvider{}, wantHost: "api.bitbucket.org", wantPath: "/2.0/repositories/alice/repo/commit/" + ref, response: fmt.Sprintf(`{"hash":%q}`, fullSHA)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousTransport := http.DefaultTransport
+			http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+				if req.Header.Get("Authorization") != "" {
+					t.Fatal("abbreviated commit lookup unexpectedly sent credentials")
+				}
+				if req.URL.Host != tt.wantHost || req.URL.EscapedPath() != tt.wantPath {
+					t.Fatalf("commit lookup URL = %s, want https://%s%s", req.URL, tt.wantHost, tt.wantPath)
+				}
+				return testHTTPResponse(http.StatusOK, tt.response), nil
+			})
+			t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+			got, err := resolveAbbreviatedCommit(tt.provider, "alice", "repo.git", ref)
+			if err != nil {
+				t.Fatalf("resolveAbbreviatedCommit() error = %v", err)
+			}
+			if got != fullSHA {
+				t.Fatalf("resolveAbbreviatedCommit() = %q, want %q", got, fullSHA)
+			}
+		})
+	}
+}
+
+func TestResolveAbbreviatedCommitErrors(t *testing.T) {
+	ref := "abcdef0"
+	tests := []struct {
+		name       string
+		provider   Provider
+		statusCode int
+		response   string
+		transport  error
+		wantError  string
+	}{
+		{name: "rate limited", provider: githubProvider{}, statusCode: http.StatusTooManyRequests, wantError: "HTTP 429"},
+		{name: "ambiguous", provider: githubProvider{}, statusCode: http.StatusUnprocessableEntity, wantError: "HTTP 422"},
+		{name: "not found", provider: gitlabProvider{host: constants.ProviderGitlabHost}, statusCode: http.StatusNotFound, wantError: "HTTP 404"},
+		{name: "network failure", provider: bitbucketProvider{}, transport: fmt.Errorf("network unavailable"), wantError: "network unavailable"},
+		{name: "mismatched response", provider: githubProvider{}, statusCode: http.StatusOK, response: fmt.Sprintf(`{"sha":%q}`, "bbbbbbb"+strings.Repeat("1", 33)), wantError: "does not match abbreviated ref"},
+		{name: "invalid response", provider: githubProvider{}, statusCode: http.StatusOK, response: `{"sha":"abcdef0"}`, wantError: "invalid full commit SHA"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousTransport := http.DefaultTransport
+			http.DefaultTransport = roundTripFunc(func(*http.Request) (*http.Response, error) {
+				if tt.transport != nil {
+					return nil, tt.transport
+				}
+				return testHTTPResponse(tt.statusCode, tt.response), nil
+			})
+			t.Cleanup(func() { http.DefaultTransport = previousTransport })
+
+			_, err := resolveAbbreviatedCommit(tt.provider, "alice", "repo", ref)
+			if err == nil || !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("resolveAbbreviatedCommit() error = %v, want %q", err, tt.wantError)
+			}
+		})
+	}
+
+	if _, err := resolveAbbreviatedCommit(genericProvider{base: "https://example.com"}, "alice", "repo", ref); err == nil || !strings.Contains(err.Error(), "does not support abbreviated commit refs") {
+		t.Fatalf("resolveAbbreviatedCommit() generic error = %v", err)
+	}
+}
+
+func testHTTPResponse(statusCode int, body string) *http.Response {
+	return &http.Response{
+		StatusCode: statusCode,
+		Status:     fmt.Sprintf("%d %s", statusCode, http.StatusText(statusCode)),
+		Header:     make(http.Header),
+		Body:       io.NopCloser(strings.NewReader(body)),
 	}
 }
 
@@ -252,7 +426,7 @@ func TestFetchStackFallsBackToShallowCloneForLFSPointer(t *testing.T) {
 
 	var gotURL string
 	var gotRef string
-	runGitClone = func(cloneURL, ref, dest string) error {
+	runGitClone = func(_ Provider, _, _ string, cloneURL, ref, dest string) error {
 		gotURL = cloneURL
 		gotRef = ref
 		if err := os.MkdirAll(filepath.Join(dest, ".git"), 0755); err != nil {
@@ -300,7 +474,7 @@ func TestFetchStackPreservesExplicitBranchForLFSFallback(t *testing.T) {
 	defer func() { runGitClone = previousRunGitClone }()
 
 	var gotRef string
-	runGitClone = func(_, ref, dest string) error {
+	runGitClone = func(_ Provider, _, _, _, ref, dest string) error {
 		gotRef = ref
 		if err := os.MkdirAll(dest, 0755); err != nil {
 			return err
@@ -326,7 +500,7 @@ func TestFetchStackKeepsArchivePathWithoutLFSPointers(t *testing.T) {
 	previousRunGitClone := runGitClone
 	defer func() { runGitClone = previousRunGitClone }()
 	cloneCalled := false
-	runGitClone = func(_, _, _ string) error {
+	runGitClone = func(Provider, string, string, string, string, string) error {
 		cloneCalled = true
 		return fmt.Errorf("unexpected clone")
 	}
@@ -346,7 +520,7 @@ func TestFetchStackKeepsArchivePathWithoutLFSPointers(t *testing.T) {
 func TestGitCloneFallbackRejectsUnresolvedPointersWithoutChangingDestination(t *testing.T) {
 	previousRunGitClone := runGitClone
 	defer func() { runGitClone = previousRunGitClone }()
-	runGitClone = func(_, _, dest string) error {
+	runGitClone = func(_ Provider, _, _, _, _, dest string) error {
 		if err := os.MkdirAll(dest, 0755); err != nil {
 			return err
 		}

--- a/internal/remote/lfs_test.go
+++ b/internal/remote/lfs_test.go
@@ -97,18 +97,19 @@ func TestGitCloneArgs(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		explicitRef bool
-		want        []string
+		name string
+		ref  string
+		want []string
 	}{
 		{
-			name: "default branch",
-			want: []string{"clone", "--depth", "1", "https://github.com/alice/repo.git", "dest"},
+			name: "implicitly resolved branch",
+			ref:  "main",
+			want: []string{"clone", "--depth", "1", "--branch", "main", "--single-branch", "https://github.com/alice/repo.git", "dest"},
 		},
 		{
-			name:        "explicit branch",
-			explicitRef: true,
-			want:        []string{"clone", "--depth", "1", "--branch", "release", "--single-branch", "https://github.com/alice/repo.git", "dest"},
+			name: "explicit branch",
+			ref:  "release",
+			want: []string{"clone", "--depth", "1", "--branch", "release", "--single-branch", "https://github.com/alice/repo.git", "dest"},
 		},
 	}
 
@@ -116,7 +117,7 @@ func TestGitCloneArgs(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := gitCloneArgs("https://github.com/alice/repo.git", "release", "dest", tt.explicitRef)
+			got := gitCloneArgs("https://github.com/alice/repo.git", tt.ref, "dest")
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Fatalf("gitCloneArgs() = %q, want %q", got, tt.want)
 			}
@@ -170,10 +171,10 @@ func TestFetchStackFallsBackToShallowCloneForLFSPointer(t *testing.T) {
 	defer func() { runGitClone = previousRunGitClone }()
 
 	var gotURL string
-	var gotExplicitRef bool
-	runGitClone = func(cloneURL, ref, dest string, explicitRef bool) error {
+	var gotRef string
+	runGitClone = func(cloneURL, ref, dest string) error {
 		gotURL = cloneURL
-		gotExplicitRef = explicitRef
+		gotRef = ref
 		if err := os.MkdirAll(filepath.Join(dest, ".git"), 0755); err != nil {
 			return err
 		}
@@ -194,8 +195,8 @@ func TestFetchStackFallsBackToShallowCloneForLFSPointer(t *testing.T) {
 	if gotURL != "https://github.com/alice/repo.git" {
 		t.Fatalf("clone URL = %q", gotURL)
 	}
-	if gotExplicitRef {
-		t.Fatal("default branch fallback should not force an explicit ref")
+	if gotRef != "main" {
+		t.Fatalf("clone ref = %q, want main", gotRef)
 	}
 	data, err := os.ReadFile(filepath.Join(dest, "assets", "model.bin"))
 	if err != nil {
@@ -209,6 +210,33 @@ func TestFetchStackFallsBackToShallowCloneForLFSPointer(t *testing.T) {
 	}
 }
 
+func TestFetchStackPreservesExplicitBranchForLFSFallback(t *testing.T) {
+	archive := testTarGz(t, map[string]string{
+		"repo-release/asset.bin": gitLFSPointerHeader + "\noid sha256:0123456789abcdef\nsize 42\n",
+	})
+	useGitHubArchive(t, archive)
+
+	previousRunGitClone := runGitClone
+	defer func() { runGitClone = previousRunGitClone }()
+
+	var gotRef string
+	runGitClone = func(_, ref, dest string) error {
+		gotRef = ref
+		if err := os.MkdirAll(dest, 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dest, "asset.bin"), []byte("resolved"), 0644)
+	}
+
+	dest := filepath.Join(t.TempDir(), "stack")
+	if err := FetchStack("https://github.com/alice/repo/tree/release", dest); err != nil {
+		t.Fatalf("FetchStack() error = %v", err)
+	}
+	if gotRef != "release" {
+		t.Fatalf("clone ref = %q, want release", gotRef)
+	}
+}
+
 func TestFetchStackKeepsArchivePathWithoutLFSPointers(t *testing.T) {
 	archive := testTarGz(t, map[string]string{
 		"repo-main/main.go": "package main\n",
@@ -218,7 +246,7 @@ func TestFetchStackKeepsArchivePathWithoutLFSPointers(t *testing.T) {
 	previousRunGitClone := runGitClone
 	defer func() { runGitClone = previousRunGitClone }()
 	cloneCalled := false
-	runGitClone = func(_, _, _ string, _ bool) error {
+	runGitClone = func(_, _, _ string) error {
 		cloneCalled = true
 		return fmt.Errorf("unexpected clone")
 	}
@@ -238,7 +266,7 @@ func TestFetchStackKeepsArchivePathWithoutLFSPointers(t *testing.T) {
 func TestGitCloneFallbackRejectsUnresolvedPointersWithoutChangingDestination(t *testing.T) {
 	previousRunGitClone := runGitClone
 	defer func() { runGitClone = previousRunGitClone }()
-	runGitClone = func(_, _, dest string, _ bool) error {
+	runGitClone = func(_, _, dest string) error {
 		if err := os.MkdirAll(dest, 0755); err != nil {
 			return err
 		}
@@ -251,7 +279,7 @@ func TestGitCloneFallbackRejectsUnresolvedPointersWithoutChangingDestination(t *
 		t.Fatal(err)
 	}
 
-	err := fetchStackWithGitClone(githubProvider{}, "alice", "repo", "main", ".", false, t.TempDir(), dest)
+	err := fetchStackWithGitClone(githubProvider{}, "alice", "repo", "main", ".", t.TempDir(), dest)
 	if err == nil || !strings.Contains(err.Error(), "unresolved Git LFS pointers") {
 		t.Fatalf("fetchStackWithGitClone() error = %v", err)
 	}
@@ -283,7 +311,7 @@ func useGitHubArchive(t *testing.T, archive []byte) {
 		switch r.URL.Path {
 		case "/repos/alice/repo":
 			fmt.Fprint(w, `{"default_branch":"main"}`)
-		case "/repos/alice/repo/tarball/main":
+		case "/repos/alice/repo/tarball/main", "/repos/alice/repo/tarball/release":
 			w.Header().Set("Content-Type", "application/gzip")
 			_, _ = w.Write(archive)
 		default:

--- a/internal/remote/lfs_test.go
+++ b/internal/remote/lfs_test.go
@@ -1,0 +1,331 @@
+package remote
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestHasGitLFSPointers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		files   map[string]string
+		wantLFS bool
+	}{
+		{
+			name: "nested pointer",
+			files: map[string]string{
+				"assets/model.bin": "version https://git-lfs.github.com/spec/v1\noid sha256:0123456789abcdef\nsize 42\n",
+				"main.go":          "package main\n",
+			},
+			wantLFS: true,
+		},
+		{
+			name: "windows line ending",
+			files: map[string]string{
+				"video.mp4": "version https://git-lfs.github.com/spec/v1\r\noid sha256:0123456789abcdef\r\nsize 42\r\n",
+			},
+			wantLFS: true,
+		},
+		{
+			name: "normal files",
+			files: map[string]string{
+				"README.md": "# Example\n",
+				"large.bin": "ordinary content without a newline",
+			},
+		},
+		{
+			name: "header prefix is not a pointer",
+			files: map[string]string{
+				"notes.txt": "version https://git-lfs.github.com/spec/v1-extra\n",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			for name, content := range tt.files {
+				path := filepath.Join(root, filepath.FromSlash(name))
+				if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			got, err := hasGitLFSPointers(root)
+			if err != nil {
+				t.Fatalf("hasGitLFSPointers() error = %v", err)
+			}
+			if got != tt.wantLFS {
+				t.Fatalf("hasGitLFSPointers() = %v, want %v", got, tt.wantLFS)
+			}
+		})
+	}
+}
+
+func TestHasGitLFSPointersMissingDirectory(t *testing.T) {
+	t.Parallel()
+
+	if _, err := hasGitLFSPointers(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("expected an error for a missing directory")
+	}
+}
+
+func TestGitCloneArgs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		explicitRef bool
+		want        []string
+	}{
+		{
+			name: "default branch",
+			want: []string{"clone", "--depth", "1", "https://github.com/alice/repo.git", "dest"},
+		},
+		{
+			name:        "explicit branch",
+			explicitRef: true,
+			want:        []string{"clone", "--depth", "1", "--branch", "release", "--single-branch", "https://github.com/alice/repo.git", "dest"},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := gitCloneArgs("https://github.com/alice/repo.git", "release", "dest", tt.explicitRef)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("gitCloneArgs() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProviderCloneURL(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		p       Provider
+		want    string
+		wantErr bool
+	}{
+		{name: "github", p: githubProvider{}, want: "https://github.com/alice/repo.git"},
+		{name: "gitlab", p: gitlabProvider{host: "gitlab.example.com"}, want: "https://gitlab.example.com/alice/repo.git"},
+		{name: "bitbucket", p: bitbucketProvider{}, want: "https://bitbucket.org/alice/repo.git"},
+		{name: "generic archive", p: genericProvider{base: "https://example.com"}, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := providerCloneURL(tt.p, "alice", "repo")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected an error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("providerCloneURL() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("providerCloneURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchStackFallsBackToShallowCloneForLFSPointer(t *testing.T) {
+	archive := testTarGz(t, map[string]string{
+		"repo-main/assets/model.bin": "version https://git-lfs.github.com/spec/v1\noid sha256:0123456789abcdef\nsize 42\n",
+	})
+	useGitHubArchive(t, archive)
+
+	previousRunGitClone := runGitClone
+	defer func() { runGitClone = previousRunGitClone }()
+
+	var gotURL string
+	var gotExplicitRef bool
+	runGitClone = func(cloneURL, ref, dest string, explicitRef bool) error {
+		gotURL = cloneURL
+		gotExplicitRef = explicitRef
+		if err := os.MkdirAll(filepath.Join(dest, ".git"), 0755); err != nil {
+			return err
+		}
+		if err := os.MkdirAll(filepath.Join(dest, "assets"), 0755); err != nil {
+			return err
+		}
+		if err := os.WriteFile(filepath.Join(dest, ".git", "config"), []byte("metadata"), 0644); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dest, "assets", "model.bin"), []byte("resolved lfs content"), 0644)
+	}
+
+	dest := filepath.Join(t.TempDir(), "stack")
+	if err := FetchStack("alice/repo", dest); err != nil {
+		t.Fatalf("FetchStack() error = %v", err)
+	}
+
+	if gotURL != "https://github.com/alice/repo.git" {
+		t.Fatalf("clone URL = %q", gotURL)
+	}
+	if gotExplicitRef {
+		t.Fatal("default branch fallback should not force an explicit ref")
+	}
+	data, err := os.ReadFile(filepath.Join(dest, "assets", "model.bin"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "resolved lfs content" {
+		t.Fatalf("model content = %q", data)
+	}
+	if _, err := os.Stat(filepath.Join(dest, ".git")); !os.IsNotExist(err) {
+		t.Fatalf(".git metadata was not removed: %v", err)
+	}
+}
+
+func TestFetchStackKeepsArchivePathWithoutLFSPointers(t *testing.T) {
+	archive := testTarGz(t, map[string]string{
+		"repo-main/main.go": "package main\n",
+	})
+	useGitHubArchive(t, archive)
+
+	previousRunGitClone := runGitClone
+	defer func() { runGitClone = previousRunGitClone }()
+	cloneCalled := false
+	runGitClone = func(_, _, _ string, _ bool) error {
+		cloneCalled = true
+		return fmt.Errorf("unexpected clone")
+	}
+
+	dest := filepath.Join(t.TempDir(), "stack")
+	if err := FetchStack("alice/repo", dest); err != nil {
+		t.Fatalf("FetchStack() error = %v", err)
+	}
+	if cloneCalled {
+		t.Fatal("normal archive unexpectedly triggered git clone")
+	}
+	if _, err := os.Stat(filepath.Join(dest, "main.go")); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGitCloneFallbackRejectsUnresolvedPointersWithoutChangingDestination(t *testing.T) {
+	previousRunGitClone := runGitClone
+	defer func() { runGitClone = previousRunGitClone }()
+	runGitClone = func(_, _, dest string, _ bool) error {
+		if err := os.MkdirAll(dest, 0755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dest, "asset.bin"), []byte(gitLFSPointerHeader+"\n"), 0644)
+	}
+
+	dest := t.TempDir()
+	sentinel := filepath.Join(dest, "sentinel.txt")
+	if err := os.WriteFile(sentinel, []byte("keep"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := fetchStackWithGitClone(githubProvider{}, "alice", "repo", "main", ".", false, t.TempDir(), dest)
+	if err == nil || !strings.Contains(err.Error(), "unresolved Git LFS pointers") {
+		t.Fatalf("fetchStackWithGitClone() error = %v", err)
+	}
+	if _, err := os.Stat(sentinel); err != nil {
+		t.Fatalf("destination changed after clone validation failed: %v", err)
+	}
+}
+
+func TestFetchStackRejectsLFSPointerFromGenericArchive(t *testing.T) {
+	archive := testTarGz(t, map[string]string{
+		"asset.bin": "version https://git-lfs.github.com/spec/v1\noid sha256:0123456789abcdef\nsize 42\n",
+	})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/gzip")
+		_, _ = w.Write(archive)
+	}))
+	defer server.Close()
+
+	err := FetchStack(server.URL+"/stack.tar.gz", filepath.Join(t.TempDir(), "stack"))
+	if err == nil || !strings.Contains(err.Error(), "cannot fall back to git clone") {
+		t.Fatalf("FetchStack() error = %v, want clone fallback error", err)
+	}
+}
+
+func useGitHubArchive(t *testing.T, archive []byte) {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/repos/alice/repo":
+			fmt.Fprint(w, `{"default_branch":"main"}`)
+		case "/repos/alice/repo/tarball/main":
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archive)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousTransport := http.DefaultTransport
+	http.DefaultTransport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		redirected := req.Clone(req.Context())
+		redirected.URL.Scheme = serverURL.Scheme
+		redirected.URL.Host = serverURL.Host
+		return previousTransport.RoundTrip(redirected)
+	})
+	t.Cleanup(func() { http.DefaultTransport = previousTransport })
+}
+
+func testTarGz(t *testing.T, files map[string]string) []byte {
+	t.Helper()
+
+	var archive strings.Builder
+	gz := gzip.NewWriter(&archive)
+	tw := tar.NewWriter(gz)
+	for name, content := range files {
+		header := &tar.Header{Name: name, Mode: 0644, Size: int64(len(content))}
+		if err := tw.WriteHeader(header); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tw.Write([]byte(content)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return []byte(archive.String())
+}

--- a/internal/remote/lfs_test.go
+++ b/internal/remote/lfs_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -122,6 +123,54 @@ func TestGitCloneArgs(t *testing.T) {
 				t.Fatalf("gitCloneArgs() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestCloneGitRepositoryCommitSHA(t *testing.T) {
+	origin := t.TempDir()
+	runTestGit(t, "init", origin)
+	runTestGit(t, "-C", origin, "config", "user.name", "Boiler Test")
+	runTestGit(t, "-C", origin, "config", "user.email", "boiler@example.invalid")
+
+	contentPath := filepath.Join(origin, "content.txt")
+	if err := os.WriteFile(contentPath, []byte("selected"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runTestGit(t, "-C", origin, "add", "content.txt")
+	runTestGit(t, "-C", origin, "commit", "-m", "selected")
+	selectedSHA := strings.TrimSpace(runTestGit(t, "-C", origin, "rev-parse", "HEAD"))
+
+	if err := os.WriteFile(contentPath, []byte("latest"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	runTestGit(t, "-C", origin, "add", "content.txt")
+	runTestGit(t, "-C", origin, "commit", "-m", "latest")
+
+	originPath := filepath.ToSlash(origin)
+	if !strings.HasPrefix(originPath, "/") {
+		originPath = "/" + originPath
+	}
+	originURL := (&url.URL{Scheme: "file", Path: originPath}).String()
+	dest := filepath.Join(t.TempDir(), "clone")
+	if err := cloneGitRepository(originURL, selectedSHA, dest); err != nil {
+		t.Fatalf("cloneGitRepository() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(runTestGit(t, "-C", dest, "rev-parse", "HEAD")); got != selectedSHA {
+		t.Fatalf("cloned SHA = %q, want %q", got, selectedSHA)
+	}
+	if got := strings.TrimSpace(runTestGit(t, "-C", dest, "branch", "--show-current")); got != "" {
+		t.Fatalf("current branch = %q, want detached HEAD", got)
+	}
+	if got := strings.TrimSpace(runTestGit(t, "-C", dest, "rev-parse", "--is-shallow-repository")); got != "true" {
+		t.Fatalf("is-shallow-repository = %q, want true", got)
+	}
+	data, err := os.ReadFile(filepath.Join(dest, "content.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "selected" {
+		t.Fatalf("content = %q, want selected", data)
 	}
 }
 
@@ -356,4 +405,14 @@ func testTarGz(t *testing.T, files map[string]string) []byte {
 		t.Fatal(err)
 	}
 	return []byte(archive.String())
+}
+
+func runTestGit(t *testing.T, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, output)
+	}
+	return string(output)
 }

--- a/internal/utils/messages.go
+++ b/internal/utils/messages.go
@@ -12,6 +12,7 @@ const (
 	// Warning messages
 	MsgWarningSnippetExists = "⚠ Warning: snippet '%s' already exists in store"
 	MsgWarningStackExists   = "⚠ Warning: stack '%s' already exists in store"
+	MsgGitLFSFallback       = "⚠️ Git LFS assets detected, falling back to git clone..."
 
 	// Prompt messages
 	MsgPromptVersionOrOverwrite = "Do you want to create a new version (v) or overwrite it (o)? "

--- a/web/src/content/docs/guides/remote-fetching.mdx
+++ b/web/src/content/docs/guides/remote-fetching.mdx
@@ -253,6 +253,10 @@ sequenceDiagram
   Store-->>User: ✓ Resource ready
 ```
 
+If a hosted repository archive contains Git LFS pointers, Boiler automatically
+falls back to a shallow Git clone and removes the repository metadata before
+storing the stack. This fallback requires both Git and Git LFS to be available.
+
 ---
 
 ## Setting Up Your Own Registry


### PR DESCRIPTION
## Summary

- detect Git LFS pointers after provider subtree or archive extraction
- fall back to a shallow clone, remove Git metadata, and reject unresolved pointers
- document the fallback and cover LFS, non-LFS, provider, and failure paths

Fixes #83

## Tests

- `go test -p 2 ./... -count=1 -timeout 120s`
- `go vet -p=2 ./...`
- `go build -p 2 -v .`
- `go test ./internal/remote -count=10 -shuffle=on`

The race detector was unavailable locally because this Windows environment does not have a C compiler for CGO.
